### PR TITLE
Remit method

### DIFF
--- a/contracts/test/Blocker.sol
+++ b/contracts/test/Blocker.sol
@@ -1,0 +1,41 @@
+// contracts/test/Blocker.sol
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.7;
+
+import "./Test721Token.sol";
+
+contract Blocker {
+  Test721Token private _testContract;
+
+  /// @dev Block by default
+  bool private _shouldBlock = true;
+
+  constructor(address contractAddress_) {
+    _testContract = Test721Token(contractAddress_);
+  }
+
+  fallback() external payable {
+    if (_shouldBlock) revert("");
+  }
+
+  function buy(
+    uint256 tokenId_,
+    uint256 purchasePrice_,
+    uint256 currentPriceForVerification_
+  ) public payable {
+    // solhint-disable avoid-low-level-calls
+    address(_testContract).call{value: msg.value}(
+      abi.encodeWithSignature(
+        "buy(uint256,uint256,uint256)",
+        tokenId_,
+        purchasePrice_,
+        currentPriceForVerification_
+      )
+    );
+  }
+
+  function collect() public {
+    _shouldBlock = false; // Stop blocking
+    _testContract.withdrawOutstandingRemittance();
+  }
+}

--- a/contracts/token/PartialCommonOwnership721.sol
+++ b/contracts/token/PartialCommonOwnership721.sol
@@ -17,7 +17,7 @@ struct TitleTransferEvent {
 
 /// @notice Reasons for sending a remittance
 enum RemittanceTriggers {
-  Lease,
+  LeaseTakeover,
   WithdrawnDeposit,
   OutstandingRemittance,
   TaxCollection
@@ -127,11 +127,11 @@ contract PartialCommonOwnership721 is ERC721 {
   );
 
   /// @notice Alert the remittance recipient that funds have been remitted to her.
-  /// @param tokenId ID of token.
+  /// @param trigger Reason for the remittance.
   /// @param recipient Recipient address.
   /// @param amount Amount in Wei.
   event LogRemittance(
-    uint256 indexed tokenId,
+    RemittanceTriggers indexed trigger,
     address indexed recipient,
     uint256 indexed amount
   );
@@ -300,7 +300,11 @@ contract PartialCommonOwnership721 is ERC721 {
         outstandingRemittances[recipient] += remittance;
         emit LogOutstandingRemittance(recipient);
       } else {
-        emit LogRemittance(_tokenId, recipient, remittance);
+        emit LogRemittance(
+          RemittanceTriggers.LeaseTakeover,
+          recipient,
+          remittance
+        );
       }
     }
 

--- a/contracts/token/PartialCommonOwnership721.sol
+++ b/contracts/token/PartialCommonOwnership721.sol
@@ -218,8 +218,7 @@ contract PartialCommonOwnership721 is ERC721 {
 
       /// Remit taxation to beneficiary.
       /// Note: This increases gas costs for all callers of `#_collectTax()`.
-      beneficiary.transfer(owed);
-      emit LogBeneficiaryRemittance(_tokenId, owed);
+      _remit(beneficiary, owed, RemittanceTriggers.TaxCollection);
 
       _forecloseIfNecessary(_tokenId);
     }

--- a/contracts/token/PartialCommonOwnership721.sol
+++ b/contracts/token/PartialCommonOwnership721.sol
@@ -136,11 +136,6 @@ contract PartialCommonOwnership721 is ERC721 {
     uint256 indexed amount
   );
 
-  /// @notice Alert deposit withdrawn.
-  /// @param tokenId ID of token deposit.
-  /// @param amount Amount withdrawn in Wei.
-  event LogDepositWithdrawal(uint256 indexed tokenId, uint256 indexed amount);
-
   //////////////////////////////
   /// Modifiers
   //////////////////////////////
@@ -541,9 +536,8 @@ contract PartialCommonOwnership721 is ERC721 {
     require(_wei <= deposit, "Cannot withdraw more than deposited");
 
     deposits[_tokenId] -= _wei;
-    payable(msg.sender).transfer(_wei);
 
-    emit LogDepositWithdrawal(_tokenId, _wei);
+    _remit(msg.sender, _wei, RemittanceTriggers.WithdrawnDeposit);
 
     _forecloseIfNecessary(_tokenId);
   }

--- a/tests/PartialCommonOwnership721/tests.ts
+++ b/tests/PartialCommonOwnership721/tests.ts
@@ -1084,8 +1084,8 @@ async function tests(config: TestConfiguration): Promise<void> {
 
         // Emits
         expect(trx)
-          .to.emit(contract, Events.DEPOSIT_WITHDRAWAL)
-          .withArgs(token, ETH1);
+          .to.emit(contract, Events.REMITTANCE)
+          .withArgs(RemittanceTriggers.WithdrawnDeposit, alice.address, ETH1);
 
         // current deposit - tax on exit
         const taxedAmt = getTaxDue(
@@ -1139,8 +1139,12 @@ async function tests(config: TestConfiguration): Promise<void> {
 
         // Emits
         expect(trx)
-          .to.emit(contract, Events.DEPOSIT_WITHDRAWAL)
-          .withArgs(token, expectedRemittance);
+          .to.emit(contract, Events.REMITTANCE)
+          .withArgs(
+            RemittanceTriggers.WithdrawnDeposit,
+            alice.address,
+            expectedRemittance
+          );
 
         // Alice's balance should reflect returned deposit minus fees
         const { delta, fees } = await alice.balanceDelta();

--- a/tests/PartialCommonOwnership721/tests.ts
+++ b/tests/PartialCommonOwnership721/tests.ts
@@ -288,9 +288,10 @@ async function tests(config: TestConfiguration): Promise<void> {
     // Events emitted
     expect(trx).to.emit(contract, Events.COLLECTION).withArgs(tokenId, due);
 
+    // Remittance emitted
     expect(trx)
-      .to.emit(contract, Events.BENEFICIARY_REMITTANCE)
-      .withArgs(tokenId, due);
+      .to.emit(contract, Events.REMITTANCE)
+      .withArgs(RemittanceTriggers.TaxCollection, beneficiary.address, due);
 
     // Deposit updates
     expect(await contract.depositOf(tokenId)).to.equal(depositBefore.sub(due));

--- a/tests/PartialCommonOwnership721/tests.ts
+++ b/tests/PartialCommonOwnership721/tests.ts
@@ -6,7 +6,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 
 import Wallet from "../helpers/Wallet";
-import { ErrorMessages, TOKENS, Events } from "./types";
+import { ErrorMessages, TOKENS, Events, RemittanceTriggers } from "./types";
 import {
   TEST_NAME,
   TEST_SYMBOL,
@@ -203,7 +203,7 @@ async function tests(config: TestConfiguration): Promise<void> {
       expect(trx)
         .to.emit(contract, Events.REMITTANCE)
         .withArgs(
-          tokenId,
+          RemittanceTriggers.LeaseTakeover,
           remittanceRecipientWallet.address,
           expectedRemittance
         );

--- a/tests/PartialCommonOwnership721/types.ts
+++ b/tests/PartialCommonOwnership721/types.ts
@@ -31,7 +31,6 @@ enum Events {
   COLLECTION = "LogCollection",
   BENEFICIARY_REMITTANCE = "LogBeneficiaryRemittance",
   REMITTANCE = "LogRemittance",
-  DEPOSIT_WITHDRAWAL = "LogDepositWithdrawal",
 }
 
 enum RemittanceTriggers {

--- a/tests/PartialCommonOwnership721/types.ts
+++ b/tests/PartialCommonOwnership721/types.ts
@@ -34,4 +34,11 @@ enum Events {
   DEPOSIT_WITHDRAWAL = "LogDepositWithdrawal",
 }
 
-export { ErrorMessages, TOKENS, Events };
+enum RemittanceTriggers {
+  LeaseTakeover,
+  WithdrawnDeposit,
+  OutstandingRemittance,
+  TaxCollection,
+}
+
+export { ErrorMessages, TOKENS, Events, RemittanceTriggers };

--- a/tests/PartialCommonOwnership721/types.ts
+++ b/tests/PartialCommonOwnership721/types.ts
@@ -29,7 +29,6 @@ enum Events {
   PRICE_CHANGE = "LogPriceChange",
   FORECLOSURE = "LogForeclosure",
   COLLECTION = "LogCollection",
-  BENEFICIARY_REMITTANCE = "LogBeneficiaryRemittance",
   REMITTANCE = "LogRemittance",
 }
 


### PR DESCRIPTION
Adds the `_remit` method and consolidates all fund transfers to use it.  This reduces the surface area for potential bugs and security issues related to external Eth transfers, and simplifies transfer-related event logging.