### PR TITLE
Removes Beneficiary.sol dependency on TokenManagement.sol

### DIFF
--- a/contracts/token/modules/Beneficiary.sol
+++ b/contracts/token/modules/Beneficiary.sol
@@ -3,9 +3,11 @@
 pragma solidity ^0.8.12;
 
 import "./interfaces/IBeneficiary.sol";
-import "./TokenManagement.sol";
 
-abstract contract Beneficiary is IBeneficiary, TokenManagement {
+/// @dev Note that this implementation is agnostic to whether or not a token
+/// has actually been minted. Resultantly, it allows setting the beneficiary of yet-to-be
+/// minuted tokens by directly calling `_setBeneficiary`.
+abstract contract Beneficiary is IBeneficiary {
   //////////////////////////////
   /// State
   //////////////////////////////
@@ -33,7 +35,6 @@ abstract contract Beneficiary is IBeneficiary, TokenManagement {
   function setBeneficiary(uint256 tokenId_, address payable beneficiary_)
     public
     override
-    _tokenMinted(tokenId_)
   {
     require(msg.sender == _beneficiaries[tokenId_], "Current beneficiary only");
     _setBeneficiary(tokenId_, beneficiary_);
@@ -44,7 +45,6 @@ abstract contract Beneficiary is IBeneficiary, TokenManagement {
     public
     view
     override
-    _tokenMinted(tokenId_)
     returns (address)
   {
     return _beneficiaries[tokenId_];
@@ -60,7 +60,6 @@ abstract contract Beneficiary is IBeneficiary, TokenManagement {
   /// @param beneficiary_ Address of beneficiary.
   function _setBeneficiary(uint256 tokenId_, address payable beneficiary_)
     internal
-    _tokenMinted(tokenId_)
   {
     _beneficiaries[tokenId_] = beneficiary_;
 

--- a/tests/PartialCommonOwnership/index.ts
+++ b/tests/PartialCommonOwnership/index.ts
@@ -547,12 +547,6 @@ describe("PartialCommonOwnership.sol", async function () {
       });
     });
     context("fails", async function () {
-      it("when token is not minted", async function () {
-        await expect(
-          contract.setBeneficiary(4, alice.address)
-        ).to.be.revertedWith(ErrorMessages.NONEXISTENT_TOKEN);
-      });
-
       it("When non-beneficiary attempts to update", async function () {
         await expect(
           alice.contract.setBeneficiary(1, alice.address)
@@ -562,17 +556,18 @@ describe("PartialCommonOwnership.sol", async function () {
   });
 
   describe("#beneficiaryOf", async function () {
-    context("fails", async function () {
-      it("when no beneficiary is set", async function () {
-        await expect(contract.beneficiaryOf(4)).to.be.revertedWith(
-          ErrorMessages.NONEXISTENT_TOKEN
-        );
-      });
-    });
+    context("fails", async function () {});
+
     context("succeeds", async function () {
       it("displays correct beneficiary after set", async function () {
         await beneficiary.contract.setBeneficiary(TOKENS.ONE, bob.address);
         expect(await contract.beneficiaryOf(TOKENS.ONE)).to.equal(bob.address);
+      });
+
+      it("returns zero address when no beneficiary is set", async () => {
+        expect(await contract.beneficiaryOf(4)).to.equal(
+          ethers.constants.AddressZero
+        );
       });
     });
   });

--- a/tests/Wrapper.ts
+++ b/tests/Wrapper.ts
@@ -145,8 +145,8 @@ async function unwrap(id: BigNumber, unwrappedTokenId: TOKENS): Promise<void> {
 
   // Verify all state is destroyed
 
-  await expect(wrapperContract.beneficiaryOf(id)).to.be.revertedWith(
-    PCOErrorMessages.NONEXISTENT_TOKEN
+  expect(await wrapperContract.beneficiaryOf(id)).to.equal(
+    ethers.constants.AddressZero
   );
 
   await expect(deployer.contract.selfAssess(id, ETH2)).to.be.revertedWith(


### PR DESCRIPTION
**Summary**

This removes the Beneficiary contract's dependency on the TokenManagement contract.  In doing so, it relaxes the requirement that a token must first be minted in order for it to have a beneficiary.  My motivation is to de-couple this module from the underlying ERC721 implementation, over which TokenManagement is a light wrapper.

**New Inheritance Graph**

![inheritance](https://user-images.githubusercontent.com/8657791/162633531-2fcb5f1d-6ee8-4022-b9d8-ec1cf9fc8dfa.png)
```
surya inheritance contracts/token/**/*.sol | dot -Tpng > inheritance.png
```
