### PR TITLE
Moves token transfer hooks into taxation module

### DIFF
--- a/contracts/token/PartialCommonOwnership.sol
+++ b/contracts/token/PartialCommonOwnership.sol
@@ -55,26 +55,4 @@ contract PartialCommonOwnership is Lease {
     delete _collectionFrequencies[tokenId_];
     delete _locked[tokenId_];
   }
-
-  /* solhint-disable no-unused-vars*/
-
-  /// @notice Collect Tax
-  function _beforeTokenTransfer(
-    address from_,
-    address to_,
-    uint256 tokenId_
-  ) internal override {
-    collectTax(tokenId_);
-  }
-
-  /// @notice Reset tax collected
-  function _afterTokenTransfer(
-    address from_,
-    address to_,
-    uint256 tokenId_
-  ) internal override {
-    _setTaxCollectedSinceLastTransfer(tokenId_, 0);
-  }
-
-  /* solhint-enable no-unused-vars*/
 }

--- a/contracts/token/modules/Lease.sol
+++ b/contracts/token/modules/Lease.sol
@@ -3,10 +3,9 @@
 pragma solidity ^0.8.12;
 
 import "./interfaces/ILease.sol";
-import "./ERC721.sol";
 import "./Taxation.sol";
 
-abstract contract Lease is ILease, ERC721, Taxation {
+abstract contract Lease is ILease, Taxation {
   //////////////////////////////
   /// State
   //////////////////////////////

--- a/contracts/token/modules/Taxation.sol
+++ b/contracts/token/modules/Taxation.sol
@@ -321,6 +321,26 @@ abstract contract Taxation is
     _forecloseIfNecessary(tokenId_);
   }
 
+  /// @notice Collect Tax
+  function _beforeTokenTransfer(
+    address from_,
+    address to_,
+    uint256 tokenId_
+  ) internal virtual override(ERC721) {
+    collectTax(tokenId_);
+    super._beforeTokenTransfer(from_, to_, tokenId_);
+  }
+
+  /// @notice Reset tax collected
+  function _afterTokenTransfer(
+    address from_,
+    address to_,
+    uint256 tokenId_
+  ) internal virtual override(ERC721) {
+    _setTaxCollectedSinceLastTransfer(tokenId_, 0);
+    super._afterTokenTransfer(from_, to_, tokenId_);
+  }
+
   //////////////////////////////
   /// Internal Setters
   //////////////////////////////


### PR DESCRIPTION
**Summary**

Because `_beforeTokenTransfer` and `_afterTokenTransfer` strictly deal with taxation (collecting tax and resetting tax collection statistics, respectively), these functions were moved into the taxation module.

**Modifies**

- Streamlines redundant inheritance: `Lease.sol` inherits from `ILease` and `Taxation`.
  - Misc: This leads me to believe the layers of abstraction are incorrect.  PCO's three core components are self-assessed valuation, taxation, and perpetual market.  Each of these modules should be interoperable with the others, according to a predefined interface, which resultingly enables business logic to be alternated (e.g. periodic instead of perpetual auctions).   The current inheritance graph maintains Leasing, Taxation, and Valuation as a single extended hierarchy rather than peers.
![inheritance](https://user-images.githubusercontent.com/8657791/162636468-2244c73d-53f8-4d46-9afc-31a76a7616fd.png)
 