### PR TITLE
Repair package boundaries and canonicalize OpenZeppelin

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     name: "coverage"
     runs-on: ubuntu-latest
     needs: []
-    # SKIP: Is not compatible w/ Hardhat preprocessing configuration and resultantly will not remap Forge-installed dependencies.
+    # SKIP: Retained only until the Forge coverage gate replaces it in Stage 7.
     if: False
     steps:
       - name: "Checkout Repo"
@@ -148,3 +148,39 @@ jobs:
           version: v1.7.1
       - name: "Run tests"
         run: "pnpm run test:forge"
+  package-consumers:
+    name: "Package Consumers"
+    runs-on: ubuntu-latest
+    needs: []
+    steps:
+      - name: "Checkout Repo"
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          submodules: recursive
+      - name: "Install Node"
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "24.18.0"
+      - name: "Enable Corepack"
+        run: |
+          corepack enable pnpm
+          corepack install --global pnpm@11.13.1
+          test "$(pnpm --version)" = "11.13.1"
+      - name: "Resolve pnpm Store"
+        id: pnpm-cache
+        run: 'echo "store=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"'
+      - name: "Cache pnpm Store"
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store }}
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
+      - name: "Install JS Dependencies"
+        run: "pnpm install --frozen-lockfile"
+      - name: "Install Foundry"
+        uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
+        with:
+          version: v1.7.1
+      - name: "Test packed package consumers"
+        run: "pnpm run test:package"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -149,7 +149,7 @@ jobs:
       - name: "Run tests"
         run: "pnpm run test:forge"
   package-consumers:
-    name: "Package Consumers"
+    name: "Compatibility and Package Consumers"
     runs-on: ubuntu-latest
     needs: []
     steps:
@@ -182,5 +182,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a # v1.9.0
         with:
           version: v1.7.1
+      - name: "Enforce compatibility manifest"
+        run: "pnpm run compatibility"
       - name: "Test packed package consumers"
         run: "pnpm run test:package"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "lib/openzeppelin-contracts"]
-	path = lib/openzeppelin-contracts
-	url = https://github.com/OpenZeppelin/openzeppelin-contracts
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std

--- a/compatibility/evidence/stage-04-package-canonical-openzeppelin.json
+++ b/compatibility/evidence/stage-04-package-canonical-openzeppelin.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "candidate": "stage-04-package-canonical-openzeppelin",
+  "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+  "mode": "metadata-stripped-equality",
+  "contracts": {
+    "contracts/Wrapper.sol:Wrapper": {
+      "creationBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x416c8a2c12a674cac0f472442830a4f0cc581e118bd7c079846886d91764d03a",
+          "candidate": "0xfcc3941bd9ef5acf1bcfed42c166f53e0b340ca7b26499ee91965bd9cc99b8cf",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0x84629a1d952a89bf833987a3afbcb7ef729ea067994a4798e2b083cc35f3a4dd",
+          "candidate": "0x84629a1d952a89bf833987a3afbcb7ef729ea067994a4798e2b083cc35f3a4dd",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 21964,
+          "candidate": 21964,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "43e3e531d71c6643b1af58cc02dd1e2a28f70bb94eaab0438ba3b2b394dabc25",
+          "candidateSha256": "43e3e531d71c6643b1af58cc02dd1e2a28f70bb94eaab0438ba3b2b394dabc25",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "runtimeBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x96b05a8bcf117adb28ff88a6321d29eb0170ad45f1a58525c6f7e09876d96a0a",
+          "candidate": "0x5ed01b3812ffb1828e17f2175bb6eb506e16adf7054e24da74cc832b77d223d0",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0x7abb1c8490e30458c1bddf3280a3408bcc9dfd498abdb2735b7c5f8080b6cd8e",
+          "candidate": "0x7abb1c8490e30458c1bddf3280a3408bcc9dfd498abdb2735b7c5f8080b6cd8e",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 21931,
+          "candidate": 21931,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "4c36f6aed0574adcc6e2e73c24be7b5fc90ae1b9be490dc05ffe237a9adcce19",
+          "candidateSha256": "4c36f6aed0574adcc6e2e73c24be7b5fc90ae1b9be490dc05ffe237a9adcce19",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "eip170": {
+        "limitBytes": 24576,
+        "baselineRuntimeSizeBytes": 21984,
+        "candidateRuntimeSizeBytes": 21984,
+        "baselineWithinLimit": true,
+        "candidateWithinLimit": true
+      }
+    },
+    "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership": {
+      "creationBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x3814717bd105739a08051b8e27479b2ec7e8ccea70b28449262e91560577fb8d",
+          "candidate": "0xbf1ed95e61438be3f54c91737b204a86d145f9b4abc8132189e072fa32fe6364",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0x0e8a161965fd0cdde6ec436cc8a556a715f2aee602bb51f147c157daf357c6fe",
+          "candidate": "0x0e8a161965fd0cdde6ec436cc8a556a715f2aee602bb51f147c157daf357c6fe",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 16071,
+          "candidate": 16071,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "01442210ea172bbd50dacfd035ad307bd52678a342f2180f97321d38a812267b",
+          "candidateSha256": "01442210ea172bbd50dacfd035ad307bd52678a342f2180f97321d38a812267b",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "runtimeBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x27fe492cdb1f8b86839558deec3186ee0998b501dbdc5960d01bfd71a0baf735",
+          "candidate": "0x21d919cfe4d73eff24a7b139480d16336212b72de61819df86a278a94d23d884",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0xa8d6f6cb7f7a3e72b471fdf442f01a16177aaa4c305d2e00a149fad04ab9d957",
+          "candidate": "0xa8d6f6cb7f7a3e72b471fdf442f01a16177aaa4c305d2e00a149fad04ab9d957",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 16039,
+          "candidate": 16039,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "a203f4e92cf30f0856473a7530df35bc9fa45a7a6e936000630a26fd82a0508e",
+          "candidateSha256": "a203f4e92cf30f0856473a7530df35bc9fa45a7a6e936000630a26fd82a0508e",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "eip170": {
+        "limitBytes": 24576,
+        "baselineRuntimeSizeBytes": 16092,
+        "candidateRuntimeSizeBytes": 16092,
+        "baselineWithinLimit": true,
+        "candidateWithinLimit": true
+      }
+    }
+  }
+}

--- a/compatibility/reviewed-differences.json
+++ b/compatibility/reviewed-differences.json
@@ -1,0 +1,45 @@
+{
+  "schemaVersion": 1,
+  "candidate": "stage-04-package-canonical-openzeppelin",
+  "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+  "allowedDifferences": [
+    {
+      "path": "$.contracts.contracts/Wrapper.sol:Wrapper.creationBytecode.keccak256",
+      "baselineValue": "0x416c8a2c12a674cac0f472442830a4f0cc581e118bd7c079846886d91764d03a",
+      "candidateValue": "0xfcc3941bd9ef5acf1bcfed42c166f53e0b340ca7b26499ee91965bd9cc99b8cf",
+      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped creation bytecode is identical."
+    },
+    {
+      "path": "$.contracts.contracts/Wrapper.sol:Wrapper.runtimeBytecode.keccak256",
+      "baselineValue": "0x96b05a8bcf117adb28ff88a6321d29eb0170ad45f1a58525c6f7e09876d96a0a",
+      "candidateValue": "0x5ed01b3812ffb1828e17f2175bb6eb506e16adf7054e24da74cc832b77d223d0",
+      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped runtime bytecode is identical."
+    },
+    {
+      "path": "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.creationBytecode.keccak256",
+      "baselineValue": "0x3814717bd105739a08051b8e27479b2ec7e8ccea70b28449262e91560577fb8d",
+      "candidateValue": "0xbf1ed95e61438be3f54c91737b204a86d145f9b4abc8132189e072fa32fe6364",
+      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped creation bytecode is identical."
+    },
+    {
+      "path": "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.runtimeBytecode.keccak256",
+      "baselineValue": "0x27fe492cdb1f8b86839558deec3186ee0998b501dbdc5960d01bfd71a0baf735",
+      "candidateValue": "0x21d919cfe4d73eff24a7b139480d16336212b72de61819df86a278a94d23d884",
+      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped runtime bytecode is identical."
+    },
+    {
+      "path": "$.gasSnapshot.entries[11]",
+      "baselineValue": "RemittanceTest:test_withdrawOutstandingRemittance(uint256) (runs: 256, μ: 29909, ~: 29922)",
+      "candidateValue": "RemittanceTest:test_withdrawOutstandingRemittance(uint256) (runs: 256, μ: 29908, ~: 29921)",
+      "reason": "The fixed-seed Forge snapshot changed by one gas in both mean and median; metadata-stripped production bytecode and behavior are unchanged."
+    }
+  ],
+  "opcodeEvidence": {
+    "mode": "metadata-stripped-equality",
+    "path": "compatibility/evidence/stage-04-package-canonical-openzeppelin.json",
+    "contracts": [
+      "contracts/Wrapper.sol:Wrapper",
+      "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership"
+    ]
+  }
+}

--- a/compatibility/reviewed-differences.json
+++ b/compatibility/reviewed-differences.json
@@ -1,6 +1,7 @@
 {
   "schemaVersion": 1,
   "candidate": "stage-04-package-canonical-openzeppelin",
+  "policy": "stage-04-source-path-metadata-and-gas",
   "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
   "allowedDifferences": [
     {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,13 +1,9 @@
-// Native dependencies
-import fs from "fs";
-
 // Import Hardhat extensions
 import "@nomiclabs/hardhat-ethers";
 import "@nomiclabs/hardhat-waffle";
 import "@nomiclabs/hardhat-web3";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
-import "hardhat-preprocessor";
 
 // Dependencies
 import { subtask } from "hardhat/config";
@@ -25,21 +21,21 @@ if (process.env.TYPE_COMPILATION !== "false") {
   require("@typechain/hardhat");
 }
 
-// Ignore Forge test files during compilation; otherwise these will throw exceptions
-// due to their using the alternative dependency system.
+// Ignore Forge-only test sources during Hardhat compilation; Forge resolves its
+// pinned test library from the retained git submodule.
 subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
   async (_, __, runSuper) => {
     const paths = await runSuper();
-    return paths.filter((p: string) => !p.endsWith(".t.sol"));
+    const forgeTestBase = path.resolve(
+      process.cwd(),
+      "contracts/test/EnhancedTest.sol"
+    );
+    return paths.filter(
+      (p: string) =>
+        !p.endsWith(".t.sol") && path.normalize(p) !== forgeTestBase
+    );
   }
 );
-
-// Load Forge dependency mapping
-const forgeRemapping = fs
-  .readFileSync("remappings.txt", "utf8")
-  .split("\n")
-  .filter(Boolean) // remove empty lines
-  .map((line) => line.trim().split("="));
 
 /**
  * @type import('hardhat/config').HardhatUserConfig
@@ -68,21 +64,6 @@ export default {
         },
       },
     },
-  },
-  preprocess: {
-    eachLine: () => ({
-      transform: (line: string) => {
-        if (line.match(/^\s*import /i)) {
-          for (const [from, to] of forgeRemapping) {
-            if (line.includes(from)) {
-              line = line.replace(from, to);
-              break;
-            }
-          }
-        }
-        return line;
-      },
-    }),
   },
   paths: {
     sources: "./contracts",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "test": "hardhat typechain && hardhat --network hardhat test && forge test -vvv",
     "prettier": "prettier --write 'contracts/**/*.sol'",
     "solhint": "solhint contracts/*.sol contracts/**/*.sol contracts/**/**/*.sol contracts/**/**/**/*.sol",
+    "compatibility": "node scripts/compatibility.js check",
     "lock:validate": "node scripts/check-pnpm-lock.js",
     "audit:ratchet": "node scripts/audit-ratchet.js",
     "publish": "npm publish --access public",

--- a/package.json
+++ b/package.json
@@ -23,9 +23,11 @@
     }
   ],
   "files": [
+    "contracts/Wrapper.sol",
+    "contracts/token/**/*.sol",
     "docs",
-    "contracts/token/*.sol",
-    "contracts/Wrapper.sol"
+    "README.md",
+    "LICENSE"
   ],
   "repository": "git@github.com:721labs/partial-common-ownership.git",
   "scripts": {
@@ -33,6 +35,7 @@
     "compile": "hardhat compile",
     "test:hardhat": "hardhat typechain && hardhat --network hardhat test",
     "test:forge": "forge test -vvv",
+    "test:package": "node scripts/test-package.js",
     "test": "hardhat typechain && hardhat --network hardhat test && forge test -vvv",
     "prettier": "prettier --write 'contracts/**/*.sol'",
     "solhint": "solhint contracts/*.sol contracts/**/*.sol contracts/**/**/*.sol contracts/**/**/**/*.sol",
@@ -40,8 +43,7 @@
     "audit:ratchet": "node scripts/audit-ratchet.js",
     "publish": "npm publish --access public",
     "coverage": "cross-env TYPE_COMPILATION=false hardhat coverage",
-    "typechain": "hardhat typechain",
-    "postinstall": "hardhat typechain"
+    "typechain": "hardhat typechain"
   },
   "devDependencies": {
     "@ethersproject/abi": "5.6.0",
@@ -50,7 +52,6 @@
     "@nomiclabs/hardhat-ethers": "2.0.5",
     "@nomiclabs/hardhat-waffle": "2.0.3",
     "@nomiclabs/hardhat-web3": "2.0.0",
-    "@openzeppelin/contracts": "4.5.0",
     "@openzeppelin/test-helpers": "0.5.15",
     "@typechain/ethers-v5": "10.0.0",
     "@typechain/hardhat": "6.0.0",
@@ -65,7 +66,6 @@
     "ethers": "5.6.2",
     "hardhat": "2.28.6",
     "hardhat-gas-reporter": "1.0.8",
-    "hardhat-preprocessor": "0.1.5",
     "prettier": "2.6.2",
     "prettier-plugin-solidity": "1.0.0-beta.19",
     "solhint": "3.3.7",
@@ -76,7 +76,9 @@
     "typescript": "4.6.3",
     "web3": "1.7.1"
   },
-  "dependencies": {},
+  "dependencies": {
+    "@openzeppelin/contracts": "4.5.0"
+  },
   "packageManager": "pnpm@11.13.1",
   "private": false
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@openzeppelin/contracts':
+        specifier: 4.5.0
+        version: 4.5.0
     devDependencies:
       '@ethersproject/abi':
         specifier: 5.6.0
@@ -29,9 +33,6 @@ importers:
       '@nomiclabs/hardhat-web3':
         specifier: 2.0.0
         version: 2.0.0(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(web3@1.7.1(bufferutil@4.0.6)(utf-8-validate@5.0.9))
-      '@openzeppelin/contracts':
-        specifier: 4.5.0
-        version: 4.5.0
       '@openzeppelin/test-helpers':
         specifier: 0.5.15
         version: 0.5.15(bn.js@4.12.0)(bufferutil@4.0.6)(supports-color@8.1.1)(utf-8-validate@5.0.9)
@@ -74,9 +75,6 @@ importers:
       hardhat-gas-reporter:
         specifier: 1.0.8
         version: 1.0.8(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
-      hardhat-preprocessor:
-        specifier: 0.1.5
-        version: 0.1.5(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
       prettier:
         specifier: 2.6.2
         version: 2.6.2
@@ -1807,9 +1805,6 @@ packages:
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
-  encode-utf8@1.0.3:
-    resolution: {integrity: sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==}
-
   encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
@@ -2256,9 +2251,6 @@ packages:
   flow-stoplight@1.0.0:
     resolution: {integrity: sha512-rDjbZUKpN8OYhB0IE/vY/I8UWO/602IIJEU/76Tv4LvYnwHCk0BCsvz4eRr9n+FQcri7L5cyaXOo0+/Kh4HisA==}
 
-  fmix@0.1.0:
-    resolution: {integrity: sha512-Y6hyofImk9JdzU8k5INtTXX1cu8LDlePWDFU5sftm9H+zKCr5SGrVjdhkvsim646cw5zD0nADj8oHyXMZmCZ9w==}
-
   follow-redirects@1.14.9:
     resolution: {integrity: sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==}
     engines: {node: '>=4.0'}
@@ -2491,11 +2483,6 @@ packages:
     peerDependencies:
       hardhat: ^2.0.2
 
-  hardhat-preprocessor@0.1.5:
-    resolution: {integrity: sha512-j8m44mmPxpxAAd0G8fPHRHOas/INZdzptSur0TNJvMEGcFdLDhbHHxBcqZVQ/bmiW42q4gC60AP4CXn9EF018g==}
-    peerDependencies:
-      hardhat: ^2.0.5
-
   hardhat@2.28.6:
     resolution: {integrity: sha512-zQze7qe+8ltwHvhX5NQ8sN1N37WWZGw8L63y+2XcPxGwAjc/SMF829z3NS6o1krX0sryhAsVBK/xrwUqlsot4Q==}
     hasBin: true
@@ -2671,10 +2658,6 @@ packages:
   import-fresh@3.3.0:
     resolution: {integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==}
     engines: {node: '>=6'}
-
-  imul@1.0.1:
-    resolution: {integrity: sha512-WFAgfwPLAjU66EKt6vRdTlKj4nAgIDQzh29JonLa4Bqtl6D8JrIMvWjCnx7xEjVNmP3U0fM5o8ZObk7d0f62bA==}
-    engines: {node: '>=0.10.0'}
 
   imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -3433,9 +3416,6 @@ packages:
 
   multihashes@0.4.21:
     resolution: {integrity: sha512-uVSvmeCWf36pU2nB4/1kzYZjsXD9vofZKpgudqkceYY5g2aZZXJ5r9lxuzoRLl1OAp28XljXsEJ/X/85ZsKmKw==}
-
-  murmur-128@0.2.1:
-    resolution: {integrity: sha512-WseEgiRkI6aMFBbj8Cg9yBj/y+OdipwVC7zUo3W2W1JAJITwouUOtpqsmGSg67EQmwwSyod7hsVsWY5LsrfQVg==}
 
   mute-stream@0.0.7:
     resolution: {integrity: sha512-r65nCZhrbXXb6dXOACihYApHw2Q6pV0M3V0PSxd74N0+D8nzAdEAITq2oAjA1jVnKI+tGvEBUpqiMh0+rW6zDQ==}
@@ -7762,8 +7742,6 @@ snapshots:
 
   emoji-regex@8.0.0: {}
 
-  encode-utf8@1.0.3: {}
-
   encodeurl@1.0.2: {}
 
   encoding-down@5.0.4:
@@ -8548,10 +8526,6 @@ snapshots:
 
   flow-stoplight@1.0.0: {}
 
-  fmix@0.1.0:
-    dependencies:
-      imul: 1.0.1
-
   follow-redirects@1.14.9(debug@4.3.4(supports-color@8.1.1)):
     optionalDependencies:
       debug: 4.3.4(supports-color@8.1.1)
@@ -8859,11 +8833,6 @@ snapshots:
     transitivePeerDependencies:
       - '@codechecks/client'
 
-  hardhat-preprocessor@0.1.5(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)):
-    dependencies:
-      hardhat: 2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)
-      murmur-128: 0.2.1
-
   hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9):
     dependencies:
       '@ethereumjs/util': 9.1.0
@@ -9088,8 +9057,6 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
-
-  imul@1.0.1: {}
 
   imurmurhash@0.1.4: {}
 
@@ -9924,12 +9891,6 @@ snapshots:
       buffer: 5.7.1
       multibase: 0.7.0
       varint: 5.0.2
-
-  murmur-128@0.2.1:
-    dependencies:
-      encode-utf8: 1.0.3
-      fmix: 0.1.0
-      imul: 1.0.1
 
   mute-stream@0.0.7: {}
 

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,3 +1,3 @@
 ds-test/=lib/forge-std/lib/ds-test/src/
 forge-std/=lib/forge-std/src/
-@openzeppelin/=lib/openzeppelin-contracts/
+@openzeppelin/=node_modules/@openzeppelin/

--- a/scripts/compatibility.js
+++ b/scripts/compatibility.js
@@ -8,6 +8,9 @@ const { spawnSync } = require("child_process");
 
 const ROOT = path.resolve(__dirname, "..");
 const BASELINE_PATH = path.join(ROOT, "compatibility", "baseline.json");
+const REVIEW_PATH = process.env.COMPATIBILITY_REVIEW
+  ? path.resolve(ROOT, process.env.COMPATIBILITY_REVIEW)
+  : path.join(ROOT, "compatibility", "reviewed-differences.json");
 const FORGE_BIN = process.env.FORGE_BIN || "forge";
 const HARDHAT_CONFIG = path.join(
   ROOT,
@@ -17,14 +20,8 @@ const HARDHAT_CONFIG = path.join(
 
 const TARGETS = [
   ["contracts/Wrapper.sol", "Wrapper"],
-  [
-    "contracts/token/PartialCommonOwnership.sol",
-    "PartialCommonOwnership",
-  ],
-  [
-    "contracts/token/modules/interfaces/IBeneficiary.sol",
-    "IBeneficiary",
-  ],
+  ["contracts/token/PartialCommonOwnership.sol", "PartialCommonOwnership"],
+  ["contracts/token/modules/interfaces/IBeneficiary.sol", "IBeneficiary"],
   ["contracts/token/modules/interfaces/ILease.sol", "ILease"],
   ["contracts/token/modules/interfaces/IRemittance.sol", "IRemittance"],
   ["contracts/token/modules/interfaces/ITaxation.sol", "ITaxation"],
@@ -147,7 +144,9 @@ function run(command, args, options = {}) {
   if (result.status !== 0) {
     const output = `${result.stdout || ""}${result.stderr || ""}`.trim();
     throw new Error(
-      `${command} ${args.join(" ")} failed with status ${result.status}\n${output}`
+      `${command} ${args.join(" ")} failed with status ${
+        result.status
+      }\n${output}`
     );
   }
 
@@ -177,6 +176,10 @@ function stableJson(value) {
   return `${JSON.stringify(sorted(value), null, 2)}\n`;
 }
 
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
 function findBuildInfo() {
   const directory = path.join(ROOT, "artifacts", "build-info");
   const candidates = fs
@@ -199,7 +202,9 @@ function findBuildInfo() {
     if (hasTargets) return buildInfo;
   }
 
-  throw new Error("No Hardhat build-info file contains every compatibility target");
+  throw new Error(
+    "No Hardhat build-info file contains every compatibility target"
+  );
 }
 
 function normalizeCompilerInput(buildInfo) {
@@ -296,7 +301,9 @@ function ethersId(value) {
 function canonicalAbiType(parameter) {
   if (!parameter.type.startsWith("tuple")) return parameter.type;
   const suffix = parameter.type.slice("tuple".length);
-  return `(${(parameter.components || []).map(canonicalAbiType).join(",")})${suffix}`;
+  return `(${(parameter.components || [])
+    .map(canonicalAbiType)
+    .join(",")})${suffix}`;
 }
 
 function abiSignature(entry) {
@@ -341,8 +348,13 @@ function normalizeStorageLayout(layout) {
         normalized[key] = value;
       }
     }
-    if (types[normalizedId] && stableJson(types[normalizedId]) !== stableJson(normalized)) {
-      throw new Error(`Storage type normalization collision for ${normalizedId}`);
+    if (
+      types[normalizedId] &&
+      stableJson(types[normalizedId]) !== stableJson(normalized)
+    ) {
+      throw new Error(
+        `Storage type normalization collision for ${normalizedId}`
+      );
     }
     types[normalizedId] = normalized;
   }
@@ -371,7 +383,8 @@ function disassemble(hex) {
   const instructions = [];
   for (let pc = 0; pc < bytes.length; pc += 1) {
     const opcode = bytes[pc];
-    const name = OPCODES[opcode] || `UNKNOWN_0x${opcode.toString(16).padStart(2, "0")}`;
+    const name =
+      OPCODES[opcode] || `UNKNOWN_0x${opcode.toString(16).padStart(2, "0")}`;
     if (opcode >= 0x60 && opcode <= 0x7f) {
       const width = opcode - 0x5f;
       const immediate = bytes.subarray(pc + 1, pc + 1 + width).toString("hex");
@@ -428,7 +441,10 @@ function selectorsFor(contractOutput) {
 
 function abiDetails(abi, contractOutput) {
   const selectors = new Map(
-    selectorsFor(contractOutput).map((entry) => [entry.signature, entry.selector])
+    selectorsFor(contractOutput).map((entry) => [
+      entry.signature,
+      entry.selector,
+    ])
   );
   const functions = [];
   const events = [];
@@ -455,7 +471,8 @@ function abiDetails(abi, contractOutput) {
 
 function contractSummary(output, source, contractName) {
   const contractOutput = output.contracts[source]?.[contractName];
-  if (!contractOutput) throw new Error(`Missing compiler output ${source}:${contractName}`);
+  if (!contractOutput)
+    throw new Error(`Missing compiler output ${source}:${contractName}`);
   const abi = normalizeAbi(contractOutput.abi || []);
 
   const summary = {
@@ -483,7 +500,10 @@ function walkAst(value, visitor) {
 function enumSummary(output) {
   const enums = [];
   for (const [source, sourceOutput] of Object.entries(output.sources || {})) {
-    if (source !== "contracts/Wrapper.sol" && !source.startsWith("contracts/token/")) {
+    if (
+      source !== "contracts/Wrapper.sol" &&
+      !source.startsWith("contracts/token/")
+    ) {
       continue;
     }
     walkAst(sourceOutput.ast, (node) => {
@@ -498,12 +518,15 @@ function enumSummary(output) {
       });
     });
   }
-  return enums.sort((a, b) => `${a.source}:${a.name}`.localeCompare(`${b.source}:${b.name}`));
+  return enums.sort((a, b) =>
+    `${a.source}:${a.name}`.localeCompare(`${b.source}:${b.name}`)
+  );
 }
 
 function xorInterfaceId(selectors) {
   let value = 0;
-  for (const selector of selectors) value ^= Number.parseInt(selector.slice(2), 16);
+  for (const selector of selectors)
+    value ^= Number.parseInt(selector.slice(2), 16);
   return `0x${(value >>> 0).toString(16).padStart(8, "0")}`;
 }
 
@@ -523,18 +546,18 @@ function interfaceSummary(output) {
 function temporaryFile(name) {
   return path.join(
     os.tmpdir(),
-    `partial-common-ownership-${process.pid}-${crypto.randomBytes(6).toString("hex")}-${name}`
+    `partial-common-ownership-${process.pid}-${crypto
+      .randomBytes(6)
+      .toString("hex")}-${name}`
   );
 }
 
 function captureHardhatTests() {
   const outputPath = temporaryFile("hardhat-tests.json");
   try {
-    run(
-      hardhatBinary(),
-      ["--config", HARDHAT_CONFIG, "test", "--no-compile"],
-      { env: { COMPAT_HARDHAT_RESULTS: outputPath } }
-    );
+    run(hardhatBinary(), ["--config", HARDHAT_CONFIG, "test", "--no-compile"], {
+      env: { COMPAT_HARDHAT_RESULTS: outputPath },
+    });
     const results = JSON.parse(fs.readFileSync(outputPath, "utf8"));
     if (results.failed.length > 0 || results.pending.length > 0) {
       throw new Error(
@@ -552,8 +575,11 @@ function captureHardhatTests() {
 
 function parseJsonAfterCompilerOutput(stdout) {
   const lines = stdout.split(/\r?\n/);
-  const firstJsonLine = lines.findIndex((line) => line.trimStart().startsWith("{"));
-  if (firstJsonLine < 0) throw new Error("Forge did not emit JSON test discovery output");
+  const firstJsonLine = lines.findIndex((line) =>
+    line.trimStart().startsWith("{")
+  );
+  if (firstJsonLine < 0)
+    throw new Error("Forge did not emit JSON test discovery output");
   return JSON.parse(lines.slice(firstJsonLine).join("\n"));
 }
 
@@ -576,13 +602,7 @@ function captureForgeTests() {
 function captureGasSnapshot() {
   const outputPath = temporaryFile("gas-snapshot.txt");
   try {
-    run(FORGE_BIN, [
-      "snapshot",
-      "--fuzz-seed",
-      "0x721",
-      "--snap",
-      outputPath,
-    ]);
+    run(FORGE_BIN, ["snapshot", "--fuzz-seed", "0x721", "--snap", outputPath]);
     return {
       fuzzSeed: "0x721",
       entries: fs
@@ -606,7 +626,9 @@ function captureErc165(interfaces) {
       interfaceId: description.interfaceId,
     })),
     { name: "invalid", interfaceId: "0xffffffff" },
-  ].sort((a, b) => `${a.name}:${a.interfaceId}`.localeCompare(`${b.name}:${b.interfaceId}`));
+  ].sort((a, b) =>
+    `${a.name}:${a.interfaceId}`.localeCompare(`${b.name}:${b.interfaceId}`)
+  );
 
   const outputPath = temporaryFile("erc165.json");
   try {
@@ -680,17 +702,30 @@ function preview(value) {
   return rendered.length <= 180 ? rendered : `${rendered.slice(0, 177)}...`;
 }
 
-function collectDifferences(expected, actual, location = "$", differences = []) {
-  if (differences.length >= 50) return differences;
+function collectDifferences(
+  expected,
+  actual,
+  location = "$",
+  differences = []
+) {
   if (Object.is(expected, actual)) return differences;
 
   if (Array.isArray(expected) && Array.isArray(actual)) {
     if (expected.length !== actual.length) {
-      differences.push(`${location}.length: ${expected.length} != ${actual.length}`);
+      differences.push({
+        path: `${location}.length`,
+        baselineValue: expected.length,
+        candidateValue: actual.length,
+      });
     }
     const length = Math.min(expected.length, actual.length);
     for (let i = 0; i < length; i += 1) {
-      collectDifferences(expected[i], actual[i], `${location}[${i}]`, differences);
+      collectDifferences(
+        expected[i],
+        actual[i],
+        `${location}[${i}]`,
+        differences
+      );
     }
     return differences;
   }
@@ -707,13 +742,238 @@ function collectDifferences(expected, actual, location = "$", differences = []) 
       new Set([...Object.keys(expected), ...Object.keys(actual)])
     ).sort();
     for (const key of keys) {
-      collectDifferences(expected[key], actual[key], `${location}.${key}`, differences);
+      collectDifferences(
+        expected[key],
+        actual[key],
+        `${location}.${key}`,
+        differences
+      );
     }
     return differences;
   }
 
-  differences.push(`${location}: ${preview(expected)} != ${preview(actual)}`);
+  differences.push({
+    path: location,
+    baselineValue: expected,
+    candidateValue: actual,
+  });
   return differences;
+}
+
+function formatDifference(difference) {
+  return `${difference.path}: ${preview(difference.baselineValue)} != ${preview(
+    difference.candidateValue
+  )}`;
+}
+
+function valuesEqual(left, right) {
+  return stableJson(left) === stableJson(right);
+}
+
+function readReviewedDifferences() {
+  if (!fs.existsSync(REVIEW_PATH)) return null;
+  const review = JSON.parse(fs.readFileSync(REVIEW_PATH, "utf8"));
+  if (review.schemaVersion !== 1) {
+    throw new Error(
+      `Unsupported compatibility review schema in ${REVIEW_PATH}`
+    );
+  }
+  if (!Array.isArray(review.allowedDifferences)) {
+    throw new Error("Compatibility review must contain allowedDifferences");
+  }
+  if (!review.candidate || typeof review.candidate !== "string") {
+    throw new Error("Compatibility review must name its candidate");
+  }
+  return review;
+}
+
+function validateReviewedDifferences(review, baselineBytes, differences) {
+  if (!review) return;
+
+  const baselineDigest = sha256(baselineBytes);
+  if (review.baselineSha256 !== baselineDigest) {
+    throw new Error(
+      `Compatibility review targets baseline ${review.baselineSha256}, but the checked-in baseline is ${baselineDigest}`
+    );
+  }
+
+  const allowedByPath = new Map();
+  for (const allowance of review.allowedDifferences) {
+    if (!allowance.path || typeof allowance.path !== "string") {
+      throw new Error("Every reviewed difference must have an exact path");
+    }
+    if (allowedByPath.has(allowance.path)) {
+      throw new Error(`Duplicate reviewed difference path: ${allowance.path}`);
+    }
+    if (!Object.prototype.hasOwnProperty.call(allowance, "baselineValue")) {
+      throw new Error(
+        `Reviewed difference ${allowance.path} is missing baselineValue`
+      );
+    }
+    if (!Object.prototype.hasOwnProperty.call(allowance, "candidateValue")) {
+      throw new Error(
+        `Reviewed difference ${allowance.path} is missing candidateValue`
+      );
+    }
+    if (!allowance.reason || typeof allowance.reason !== "string") {
+      throw new Error(
+        `Reviewed difference ${allowance.path} is missing its reason`
+      );
+    }
+    allowedByPath.set(allowance.path, allowance);
+  }
+
+  const usedPaths = new Set();
+  const rejected = [];
+  for (const difference of differences) {
+    const allowance = allowedByPath.get(difference.path);
+    if (!allowance) {
+      rejected.push(`unreviewed: ${formatDifference(difference)}`);
+      continue;
+    }
+    usedPaths.add(difference.path);
+    if (
+      !valuesEqual(allowance.baselineValue, difference.baselineValue) ||
+      !valuesEqual(allowance.candidateValue, difference.candidateValue)
+    ) {
+      rejected.push(
+        `review does not match exact old/new values: ${formatDifference(
+          difference
+        )}`
+      );
+    }
+  }
+
+  for (const allowance of review.allowedDifferences) {
+    if (!usedPaths.has(allowance.path)) {
+      rejected.push(`unused reviewed difference: ${allowance.path}`);
+    }
+  }
+
+  if (rejected.length > 0) {
+    throw new Error(
+      `Compatibility candidate ${
+        review.candidate
+      } did not match its review:\n${rejected
+        .map((entry) => `- ${entry}`)
+        .join("\n")}`
+    );
+  }
+}
+
+function reviewedOpcodeEvidence(review, baseline, candidate) {
+  const configuration = review.opcodeEvidence;
+  if (!configuration) return null;
+  if (configuration.mode !== "metadata-stripped-equality") {
+    throw new Error(`Unsupported opcode evidence mode: ${configuration.mode}`);
+  }
+  if (
+    !Array.isArray(configuration.contracts) ||
+    configuration.contracts.length === 0
+  ) {
+    throw new Error("Opcode evidence must list at least one contract");
+  }
+
+  const contracts = {};
+  for (const qualifiedName of configuration.contracts) {
+    const baselineContract = baseline.contracts[qualifiedName];
+    const candidateContract = candidate.contracts[qualifiedName];
+    if (!baselineContract || !candidateContract) {
+      throw new Error(`Opcode evidence contract is missing: ${qualifiedName}`);
+    }
+
+    const contractEvidence = {};
+    for (const bytecodeKind of ["creationBytecode", "runtimeBytecode"]) {
+      const baselineBytecode = baselineContract[bytecodeKind];
+      const candidateBytecode = candidateContract[bytecodeKind];
+      const opcodesEqual =
+        baselineBytecode.metadataStrippedOpcodes ===
+        candidateBytecode.metadataStrippedOpcodes;
+      if (!opcodesEqual) {
+        throw new Error(
+          `${qualifiedName} ${bytecodeKind} has a metadata-stripped opcode change; the equality evidence cannot approve it`
+        );
+      }
+      contractEvidence[bytecodeKind] = {
+        rawKeccak256: {
+          baseline: baselineBytecode.keccak256,
+          candidate: candidateBytecode.keccak256,
+          changed: baselineBytecode.keccak256 !== candidateBytecode.keccak256,
+        },
+        metadataStrippedKeccak256: {
+          baseline: baselineBytecode.metadataStrippedKeccak256,
+          candidate: candidateBytecode.metadataStrippedKeccak256,
+          equal:
+            baselineBytecode.metadataStrippedKeccak256 ===
+            candidateBytecode.metadataStrippedKeccak256,
+        },
+        metadataStrippedSizeBytes: {
+          baseline: baselineBytecode.metadataStrippedSizeBytes,
+          candidate: candidateBytecode.metadataStrippedSizeBytes,
+          equal:
+            baselineBytecode.metadataStrippedSizeBytes ===
+            candidateBytecode.metadataStrippedSizeBytes,
+        },
+        metadataStrippedOpcodes: {
+          baselineSha256: sha256(baselineBytecode.metadataStrippedOpcodes),
+          candidateSha256: sha256(candidateBytecode.metadataStrippedOpcodes),
+          equal: opcodesEqual,
+          diff: [],
+        },
+      };
+    }
+
+    const baselineRuntimeSize = baselineContract.runtimeBytecode.sizeBytes;
+    const candidateRuntimeSize = candidateContract.runtimeBytecode.sizeBytes;
+    contractEvidence.eip170 = {
+      limitBytes: 24_576,
+      baselineRuntimeSizeBytes: baselineRuntimeSize,
+      candidateRuntimeSizeBytes: candidateRuntimeSize,
+      baselineWithinLimit: baselineRuntimeSize <= 24_576,
+      candidateWithinLimit: candidateRuntimeSize <= 24_576,
+    };
+    contracts[qualifiedName] = contractEvidence;
+  }
+
+  return sorted({
+    schemaVersion: 1,
+    candidate: review.candidate,
+    baselineSha256: review.baselineSha256,
+    mode: configuration.mode,
+    contracts,
+  });
+}
+
+function validateOpcodeEvidence(review, baseline, candidate) {
+  const evidence = reviewedOpcodeEvidence(review, baseline, candidate);
+  if (!evidence) return;
+  if (
+    !review.opcodeEvidence.path ||
+    typeof review.opcodeEvidence.path !== "string"
+  ) {
+    throw new Error(
+      "Opcode evidence configuration must name its checked-in path"
+    );
+  }
+
+  const evidencePath = path.resolve(ROOT, review.opcodeEvidence.path);
+  const compatibilityRoot = `${path.join(ROOT, "compatibility")}${path.sep}`;
+  if (!evidencePath.startsWith(compatibilityRoot)) {
+    throw new Error("Opcode evidence must be stored under compatibility/");
+  }
+  if (!fs.existsSync(evidencePath)) {
+    throw new Error(`Checked-in opcode evidence is missing: ${evidencePath}`);
+  }
+  const checkedInEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+  if (!valuesEqual(checkedInEvidence, evidence)) {
+    const evidenceDifferences = collectDifferences(checkedInEvidence, evidence);
+    throw new Error(
+      `Checked-in opcode evidence is stale:\n${evidenceDifferences
+        .slice(0, 20)
+        .map((difference) => `- ${formatDifference(difference)}`)
+        .join("\n")}`
+    );
+  }
 }
 
 async function main() {
@@ -724,29 +984,52 @@ async function main() {
     return;
   }
 
+  if (command === "capture" && fs.existsSync(BASELINE_PATH)) {
+    throw new Error(
+      `Refusing to overwrite the compatibility baseline at ${BASELINE_PATH}`
+    );
+  }
+
   const manifest = await generateManifest();
   if (command === "capture") {
     fs.writeFileSync(BASELINE_PATH, stableJson(manifest));
     console.log(
-      `Captured ${manifest.tests.hardhat.count} Hardhat and ${manifest.tests.forge.count} Forge tests in ${path.relative(ROOT, BASELINE_PATH)}`
+      `Captured ${manifest.tests.hardhat.count} Hardhat and ${
+        manifest.tests.forge.count
+      } Forge tests in ${path.relative(ROOT, BASELINE_PATH)}`
     );
     return;
   }
 
   if (!fs.existsSync(BASELINE_PATH)) {
-    throw new Error("Compatibility baseline is missing; run the capture command once");
+    throw new Error(
+      "Compatibility baseline is missing; run the capture command once"
+    );
   }
-  const baseline = JSON.parse(fs.readFileSync(BASELINE_PATH, "utf8"));
+  const baselineBytes = fs.readFileSync(BASELINE_PATH);
+  const baseline = JSON.parse(baselineBytes);
   const differences = collectDifferences(baseline, manifest);
-  if (differences.length > 0) {
+  const review = readReviewedDifferences();
+  if (differences.length > 0 && !review) {
     console.error("Compatibility check failed. First differences:");
-    for (const difference of differences) console.error(`- ${difference}`);
+    for (const difference of differences.slice(0, 50)) {
+      console.error(`- ${formatDifference(difference)}`);
+    }
     process.exitCode = 1;
     return;
   }
 
+  validateReviewedDifferences(review, baselineBytes, differences);
+  if (review) validateOpcodeEvidence(review, baseline, manifest);
+
   console.log(
-    `Compatibility check passed: ${manifest.tests.hardhat.count} Hardhat + ${manifest.tests.forge.count} Forge tests`
+    `Compatibility check passed: ${manifest.tests.hardhat.count} Hardhat + ${
+      manifest.tests.forge.count
+    } Forge tests${
+      review
+        ? `; ${differences.length} exact reviewed differences for ${review.candidate}`
+        : ""
+    }`
   );
 }
 

--- a/scripts/compatibility.js
+++ b/scripts/compatibility.js
@@ -38,6 +38,45 @@ const REQUIRED_OUTPUTS = [
   "storageLayout",
 ];
 
+const STAGE_04_RAW_BYTECODE_HASH_PATHS = new Set([
+  "$.contracts.contracts/Wrapper.sol:Wrapper.creationBytecode.keccak256",
+  "$.contracts.contracts/Wrapper.sol:Wrapper.runtimeBytecode.keccak256",
+  "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.creationBytecode.keccak256",
+  "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.runtimeBytecode.keccak256",
+]);
+
+const REVIEW_POLICIES = Object.freeze({
+  "stage-04-source-path-metadata-and-gas": Object.freeze({
+    candidate: "stage-04-package-canonical-openzeppelin",
+    requiredOpcodeEvidence: Object.freeze({
+      mode: "metadata-stripped-equality",
+      path: "compatibility/evidence/stage-04-package-canonical-openzeppelin.json",
+      contracts: Object.freeze([
+        "contracts/Wrapper.sol:Wrapper",
+        "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership",
+      ]),
+    }),
+    permits(reviewPath) {
+      return (
+        STAGE_04_RAW_BYTECODE_HASH_PATHS.has(reviewPath) ||
+        /^\$\.gasSnapshot\.entries\[\d+\]$/.test(reviewPath)
+      );
+    },
+  }),
+});
+
+const NON_WAIVABLE_REVIEW_PATHS = [
+  {
+    name: "contract ABI, functions, events, errors, or storage layout",
+    pattern:
+      /^\$\.contracts\..+\.(?:abi|functions|events|errors|storageLayout)(?:\.|\[|$)/,
+  },
+  {
+    name: "interfaces, enums, or ERC165 results",
+    pattern: /^\$\.(?:interfaces|enums|erc165)(?:\.|\[|$)/,
+  },
+];
+
 const OPCODES = {
   0x00: "STOP",
   0x01: "ADD",
@@ -784,12 +823,73 @@ function readReviewedDifferences() {
   if (!review.candidate || typeof review.candidate !== "string") {
     throw new Error("Compatibility review must name its candidate");
   }
+  if (!review.policy || typeof review.policy !== "string") {
+    throw new Error("Compatibility review must name an enumerated policy");
+  }
   return review;
+}
+
+function reviewPolicy(review) {
+  const policy = REVIEW_POLICIES[review.policy];
+  if (!policy) {
+    throw new Error(
+      `Unknown compatibility review policy: ${review.policy}. Add a named policy to scripts/compatibility.js before reviewing a new class of change.`
+    );
+  }
+  if (policy.candidate !== review.candidate) {
+    throw new Error(
+      `Compatibility review policy ${review.policy} is restricted to ${policy.candidate}, not ${review.candidate}`
+    );
+  }
+  if (policy.requiredOpcodeEvidence) {
+    const required = policy.requiredOpcodeEvidence;
+    const supplied = review.opcodeEvidence;
+    if (!supplied || typeof supplied !== "object") {
+      throw new Error(
+        `Compatibility review policy ${review.policy} requires opcode evidence`
+      );
+    }
+    if (supplied.mode !== required.mode) {
+      throw new Error(
+        `Compatibility review policy ${review.policy} requires opcode evidence mode ${required.mode}`
+      );
+    }
+    if (supplied.path !== required.path) {
+      throw new Error(
+        `Compatibility review policy ${review.policy} requires checked-in opcode evidence at ${required.path}`
+      );
+    }
+    if (!Array.isArray(supplied.contracts)) {
+      throw new Error(
+        `Compatibility review policy ${review.policy} requires an exact opcode evidence contract set`
+      );
+    }
+    const requiredContracts = [...required.contracts].sort();
+    const suppliedContracts = [...new Set(supplied.contracts)].sort();
+    if (
+      suppliedContracts.length !== supplied.contracts.length ||
+      !valuesEqual(suppliedContracts, requiredContracts)
+    ) {
+      throw new Error(
+        `Compatibility review policy ${
+          review.policy
+        } requires opcode evidence for exactly: ${requiredContracts.join(", ")}`
+      );
+    }
+  }
+  return policy;
+}
+
+function nonWaivableReviewDomain(reviewPath) {
+  return NON_WAIVABLE_REVIEW_PATHS.find(({ pattern }) =>
+    pattern.test(reviewPath)
+  );
 }
 
 function validateReviewedDifferences(review, baselineBytes, differences) {
   if (!review) return;
 
+  const policy = reviewPolicy(review);
   const baselineDigest = sha256(baselineBytes);
   if (review.baselineSha256 !== baselineDigest) {
     throw new Error(
@@ -804,6 +904,17 @@ function validateReviewedDifferences(review, baselineBytes, differences) {
     }
     if (allowedByPath.has(allowance.path)) {
       throw new Error(`Duplicate reviewed difference path: ${allowance.path}`);
+    }
+    const protectedDomain = nonWaivableReviewDomain(allowance.path);
+    if (protectedDomain) {
+      throw new Error(
+        `Reviewed differences may never waive ${protectedDomain.name}: ${allowance.path}`
+      );
+    }
+    if (!policy.permits(allowance.path)) {
+      throw new Error(
+        `Compatibility review policy ${review.policy} does not permit path: ${allowance.path}`
+      );
     }
     if (!Object.prototype.hasOwnProperty.call(allowance, "baselineValue")) {
       throw new Error(

--- a/scripts/test-package.js
+++ b/scripts/test-package.js
@@ -1,0 +1,484 @@
+const { spawnSync } = require("child_process");
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const { createRequire } = require("module");
+
+const PROJECT_ROOT = path.resolve(__dirname, "..");
+const PACKAGE_NAME = "@721labs/partial-common-ownership";
+const PNPM_VERSION = "11.13.1";
+const HARDHAT_VERSION = "2.28.6";
+const FOUNDRY_VERSION = "1.7.1";
+const SOLC_VERSION = "0.8.12";
+
+const pnpm =
+  process.env.PNPM_BIN || (process.platform === "win32" ? "pnpm.cmd" : "pnpm");
+const forge =
+  process.env.FORGE_BIN ||
+  (process.platform === "win32" ? "forge.exe" : "forge");
+
+function run(command, args, options = {}) {
+  const capture = options.capture === true;
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || PROJECT_ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      CI: "true",
+      COREPACK_ENABLE_DOWNLOAD_PROMPT: "0",
+      ...options.env,
+    },
+    stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+  });
+
+  if (result.error) {
+    throw new Error(
+      `Unable to run ${command} ${args.join(" ")}: ${result.error.message}`
+    );
+  }
+
+  if (result.status !== 0) {
+    const details = capture
+      ? `\n${[result.stdout, result.stderr].filter(Boolean).join("\n").trim()}`
+      : "";
+    throw new Error(
+      `${command} ${args.join(" ")} exited with status ${
+        result.status
+      }.${details}`
+    );
+  }
+
+  return capture ? result.stdout.trim() : "";
+}
+
+function writeFile(file, contents) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, contents.endsWith("\n") ? contents : `${contents}\n`);
+}
+
+function writeJson(file, value) {
+  writeFile(file, JSON.stringify(value, null, 2));
+}
+
+function listFiles(root, filter = () => true) {
+  if (!fs.existsSync(root)) {
+    throw new Error(`Required package path is missing: ${root}`);
+  }
+
+  const files = [];
+  const visit = (directory) => {
+    for (const entry of fs
+      .readdirSync(directory, { withFileTypes: true })
+      .sort((a, b) => a.name.localeCompare(b.name))) {
+      const absolute = path.join(directory, entry.name);
+      if (entry.isSymbolicLink()) {
+        throw new Error(
+          `Package inputs may not be symbolic links: ${absolute}`
+        );
+      }
+      if (entry.isDirectory()) {
+        visit(absolute);
+      } else if (entry.isFile() && filter(absolute)) {
+        files.push(absolute);
+      }
+    }
+  };
+
+  visit(root);
+  return files;
+}
+
+function projectRelative(file) {
+  return path.relative(PROJECT_ROOT, file).split(path.sep).join("/");
+}
+
+function expectedPackageFiles() {
+  const required = [
+    "contracts/Wrapper.sol",
+    "README.md",
+    "LICENSE",
+    "package.json",
+  ];
+  for (const file of required) {
+    if (!fs.statSync(path.join(PROJECT_ROOT, file)).isFile()) {
+      throw new Error(`Required package file is missing: ${file}`);
+    }
+  }
+
+  const tokenFiles = listFiles(
+    path.join(PROJECT_ROOT, "contracts", "token"),
+    (file) => file.endsWith(".sol")
+  ).map(projectRelative);
+  const docs = listFiles(path.join(PROJECT_ROOT, "docs")).map(projectRelative);
+
+  if (tokenFiles.length === 0) {
+    throw new Error("No production contracts/token Solidity files were found.");
+  }
+  if (docs.length === 0) {
+    throw new Error("No documentation files were found.");
+  }
+
+  return [...new Set([...required, ...tokenFiles, ...docs])].sort();
+}
+
+function inspectTarball(tarball, extractionDirectory) {
+  const listing = run("tar", ["-tzf", tarball], { capture: true });
+  const entries = listing.split(/\r?\n/).filter(Boolean);
+  const actual = [];
+  const seen = new Set();
+
+  for (const entry of entries) {
+    if (!entry.startsWith("package/")) {
+      throw new Error(`Tarball entry is outside package/: ${entry}`);
+    }
+    if (entry.endsWith("/")) continue;
+
+    const relative = entry.slice("package/".length);
+    if (!relative || relative.includes("..") || path.isAbsolute(relative)) {
+      throw new Error(`Unsafe tarball entry: ${entry}`);
+    }
+    if (seen.has(relative)) {
+      throw new Error(`Duplicate tarball entry: ${relative}`);
+    }
+    seen.add(relative);
+    actual.push(relative);
+  }
+
+  const expected = expectedPackageFiles();
+  actual.sort();
+
+  const missing = expected.filter((file) => !seen.has(file));
+  const unexpected = actual.filter((file) => !expected.includes(file));
+  if (missing.length || unexpected.length) {
+    const messages = ["Packed tarball contents do not match the allowlist."];
+    if (missing.length) messages.push(`Missing: ${missing.join(", ")}`);
+    if (unexpected.length) {
+      messages.push(`Unexpected: ${unexpected.join(", ")}`);
+    }
+    throw new Error(messages.join("\n"));
+  }
+
+  const forbidden = actual.filter(
+    (file) =>
+      /(^|\/)(test|tests|fixtures?|artifacts?|cache(?:-hh)?|out|lib|scripts)(\/|$)/.test(
+        file
+      ) ||
+      /(^|\/).*\.t\.sol$/.test(file) ||
+      /(^|\/)(foundry\.toml|hardhat\.config\.[^/]+|remappings\.txt|pnpm-lock\.yaml|yarn\.lock)$/.test(
+        file
+      )
+  );
+  if (forbidden.length) {
+    throw new Error(`Forbidden package entries: ${forbidden.join(", ")}`);
+  }
+
+  fs.mkdirSync(extractionDirectory, { recursive: true });
+  run("tar", ["-xzf", tarball, "-C", extractionDirectory]);
+
+  const packedManifest = JSON.parse(
+    fs.readFileSync(
+      path.join(extractionDirectory, "package", "package.json"),
+      "utf8"
+    )
+  );
+  if (packedManifest.name !== PACKAGE_NAME) {
+    throw new Error(
+      `Packed package name is ${packedManifest.name}; expected ${PACKAGE_NAME}.`
+    );
+  }
+
+  const installScripts = ["preinstall", "install", "postinstall"].filter(
+    (script) => packedManifest.scripts && packedManifest.scripts[script]
+  );
+  if (installScripts.length) {
+    throw new Error(
+      `Packed package must not run consumer install scripts: ${installScripts.join(
+        ", "
+      )}`
+    );
+  }
+
+  const openZeppelinVersion =
+    packedManifest.dependencies &&
+    packedManifest.dependencies["@openzeppelin/contracts"];
+  if (!/^\d+\.\d+\.\d+$/.test(openZeppelinVersion || "")) {
+    throw new Error(
+      "@openzeppelin/contracts must be an exact regular dependency in the packed package."
+    );
+  }
+  if (
+    packedManifest.devDependencies &&
+    packedManifest.devDependencies["@openzeppelin/contracts"]
+  ) {
+    throw new Error(
+      "@openzeppelin/contracts must have one canonical declaration, not a devDependency duplicate."
+    );
+  }
+
+  return { fileCount: actual.length, openZeppelinVersion };
+}
+
+function consumerSource() {
+  return `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.12;
+
+import {Wrapper} from "${PACKAGE_NAME}/contracts/Wrapper.sol";
+import {PartialCommonOwnership} from "${PACKAGE_NAME}/contracts/token/PartialCommonOwnership.sol";
+
+contract ConsumerWrapper is Wrapper {}
+
+contract ConsumerPCO is PartialCommonOwnership {
+  function mintForConsumer(
+    uint256 tokenId_,
+    address owner_,
+    address payable beneficiary_
+  ) external payable {
+    _mint(
+      tokenId_,
+      owner_,
+      msg.value,
+      1 ether,
+      beneficiary_,
+      1,
+      1 days
+    );
+  }
+}`;
+}
+
+function prepareCleanConsumer(
+  directory,
+  tarball,
+  manifest,
+  workspaceConfiguration = ""
+) {
+  fs.mkdirSync(directory, { recursive: true });
+  fs.copyFileSync(tarball, path.join(directory, "package.tgz"));
+  writeJson(path.join(directory, "package.json"), manifest);
+  if (workspaceConfiguration) {
+    writeFile(
+      path.join(directory, "pnpm-workspace.yaml"),
+      workspaceConfiguration
+    );
+  }
+
+  run(pnpm, ["install", "--lockfile-only", "--ignore-scripts"], {
+    cwd: directory,
+  });
+
+  // The compile is deliberately performed after a fresh, frozen install.
+  fs.rmSync(path.join(directory, "node_modules"), {
+    recursive: true,
+    force: true,
+  });
+  run(pnpm, ["install", "--frozen-lockfile"], { cwd: directory });
+}
+
+function assertArtifacts(directory, relativePaths, tool) {
+  const missing = relativePaths.filter(
+    (relative) => !fs.existsSync(path.join(directory, relative))
+  );
+  if (missing.length) {
+    throw new Error(
+      `${tool} did not produce expected consumer artifacts: ${missing.join(
+        ", "
+      )}`
+    );
+  }
+}
+
+function buildHardhatConsumer(directory, tarball) {
+  prepareCleanConsumer(
+    directory,
+    tarball,
+    {
+      name: "pco-hardhat-package-consumer",
+      version: "0.0.0",
+      private: true,
+      packageManager: `pnpm@${PNPM_VERSION}`,
+      dependencies: {
+        [PACKAGE_NAME]: "file:./package.tgz",
+      },
+      devDependencies: {
+        hardhat: HARDHAT_VERSION,
+      },
+    },
+    // Hardhat 2 resolves Solidity libraries from the project root, so expose
+    // only the package's declared OpenZeppelin dependency there. Its legacy
+    // keccak dependency has a JS fallback and does not need a native build.
+    `publicHoistPattern:
+  - "@openzeppelin/contracts"
+allowBuilds:
+  keccak@3.0.4: false`
+  );
+
+  writeFile(
+    path.join(directory, "contracts", "Consumer.sol"),
+    consumerSource()
+  );
+  writeFile(
+    path.join(directory, "hardhat.config.cjs"),
+    `module.exports = {
+  solidity: {
+    version: "${SOLC_VERSION}",
+    settings: {
+      evmVersion: "london",
+      optimizer: { enabled: false, runs: 200 },
+      viaIR: false,
+      metadata: { bytecodeHash: "ipfs", useLiteralContent: false }
+    }
+  },
+  paths: {
+    sources: "./contracts",
+    cache: "./cache",
+    artifacts: "./artifacts"
+  }
+};`
+  );
+
+  run(pnpm, ["exec", "hardhat", "compile"], { cwd: directory });
+  assertArtifacts(
+    directory,
+    [
+      "artifacts/contracts/Consumer.sol/ConsumerWrapper.json",
+      "artifacts/contracts/Consumer.sol/ConsumerPCO.json",
+    ],
+    "Hardhat"
+  );
+}
+
+function resolveInstalledPackage(fromDirectory, packageName) {
+  const resolver = createRequire(path.join(fromDirectory, "package.json"));
+  return path.dirname(resolver.resolve(`${packageName}/package.json`));
+}
+
+function tomlString(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+function buildForgeConsumer(directory, tarball) {
+  prepareCleanConsumer(directory, tarball, {
+    name: "pco-forge-package-consumer",
+    version: "0.0.0",
+    private: true,
+    packageManager: `pnpm@${PNPM_VERSION}`,
+    dependencies: {
+      [PACKAGE_NAME]: "file:./package.tgz",
+    },
+  });
+
+  const packageRoot = resolveInstalledPackage(directory, PACKAGE_NAME);
+  const openZeppelinRoot = resolveInstalledPackage(
+    packageRoot,
+    "@openzeppelin/contracts"
+  );
+
+  writeFile(path.join(directory, "src", "Consumer.sol"), consumerSource());
+  writeFile(
+    path.join(directory, "foundry.toml"),
+    `[profile.default]
+src = "src"
+out = "out"
+libs = ["node_modules"]
+solc_version = "${SOLC_VERSION}"
+auto_detect_solc = false
+auto_detect_remappings = false
+evm_version = "london"
+optimizer = false
+optimizer_runs = 200
+via_ir = false
+bytecode_hash = "ipfs"
+cbor_metadata = true
+use_literal_content = false
+remappings = [
+  "${PACKAGE_NAME}/=${tomlString(packageRoot)}/",
+  "@openzeppelin/=${tomlString(path.dirname(openZeppelinRoot))}/"
+]`
+  );
+
+  run(forge, ["build", "--root", directory], {
+    cwd: directory,
+    env: { FOUNDRY_DISABLE_NIGHTLY_WARNING: "1" },
+  });
+  assertArtifacts(
+    directory,
+    [
+      "out/Consumer.sol/ConsumerWrapper.json",
+      "out/Consumer.sol/ConsumerPCO.json",
+    ],
+    "Forge"
+  );
+}
+
+function verifyToolVersions() {
+  const actualPnpmVersion = run(pnpm, ["--version"], { capture: true });
+  if (actualPnpmVersion !== PNPM_VERSION) {
+    throw new Error(
+      `pnpm ${PNPM_VERSION} is required; found ${actualPnpmVersion}.`
+    );
+  }
+
+  const actualForgeVersion = run(forge, ["--version"], { capture: true });
+  if (
+    !new RegExp(`\\b${FOUNDRY_VERSION.replace(/\./g, "\\.")}\\b`).test(
+      actualForgeVersion
+    )
+  ) {
+    throw new Error(
+      `Forge ${FOUNDRY_VERSION} is required; found ${actualForgeVersion}. Set FORGE_BIN to the pinned binary.`
+    );
+  }
+}
+
+function main() {
+  verifyToolVersions();
+  const temporaryRoot = fs.mkdtempSync(
+    path.join(os.tmpdir(), "partial-common-ownership-package-")
+  );
+  let preserveTemporaryRoot = process.env.KEEP_PACKAGE_TEST_TEMP === "1";
+
+  try {
+    const packDirectory = path.join(temporaryRoot, "pack");
+    fs.mkdirSync(packDirectory, { recursive: true });
+    run(pnpm, ["pack", "--pack-destination", packDirectory], {
+      cwd: PROJECT_ROOT,
+    });
+
+    const tarballs = fs
+      .readdirSync(packDirectory)
+      .filter((file) => file.endsWith(".tgz"));
+    if (tarballs.length !== 1) {
+      throw new Error(
+        `Expected pnpm pack to create one tarball; found ${tarballs.length}.`
+      );
+    }
+    const tarball = path.join(packDirectory, tarballs[0]);
+    const packageResult = inspectTarball(
+      tarball,
+      path.join(temporaryRoot, "unpacked")
+    );
+
+    buildHardhatConsumer(path.join(temporaryRoot, "hardhat-consumer"), tarball);
+    buildForgeConsumer(path.join(temporaryRoot, "forge-consumer"), tarball);
+
+    console.log(
+      `Package gate passed: ${packageResult.fileCount} allowlisted files, OpenZeppelin ${packageResult.openZeppelinVersion}, Hardhat ${HARDHAT_VERSION}, and Forge ${FOUNDRY_VERSION}.`
+    );
+  } catch (error) {
+    if (process.env.KEEP_PACKAGE_TEST_TEMP === "1") {
+      console.error(`Package test files retained at ${temporaryRoot}`);
+    }
+    throw error;
+  } finally {
+    if (!preserveTemporaryRoot) {
+      fs.rmSync(temporaryRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+try {
+  main();
+} catch (error) {
+  console.error(error && error.stack ? error.stack : error);
+  process.exit(1);
+}


### PR DESCRIPTION
<!-- modernization-chronology:start -->
## Modernization chronology

- **Phase:** Stage 4 — package boundaries and one canonical OpenZeppelin source
- **Predecessor:** [#83 — pnpm migration](https://github.com/721labs/partial-common-ownership/pull/83)
- **This checkpoint:** [#84](https://github.com/721labs/partial-common-ownership/pull/84) — merged at [81d41caf40b8a1d7085a051d4ed7190f4cddd56c](https://github.com/721labs/partial-common-ownership/commit/81d41caf40b8a1d7085a051d4ed7190f4cddd56c) on 2026-07-16T15:18:17Z
- **Successor:** [#85 — OpenZeppelin 4.9.6 bridge](https://github.com/721labs/partial-common-ownership/pull/85)
- **Relationship:** Historical merge order: packaging and source resolution were repaired before upgrading OpenZeppelin.
<!-- modernization-chronology:end -->

## What changed

- removed the broken consumer `postinstall`
- packed exactly 19 allowlisted production/documentation files
- moved exact OpenZeppelin 4.5.0 to runtime dependencies
- made pnpm's OpenZeppelin install canonical for both Hardhat and Forge
- removed the duplicate OpenZeppelin git submodule and Hardhat preprocessor
- retained only the pinned forge-std submodule
- added clean packed-tarball Hardhat and Forge consumer builds
- added CI enforcement for package consumers and reviewed compatibility evidence

## Consumer proof

The packed tarball compiles a direct `Wrapper` import and a concrete `PartialCommonOwnership` subclass in isolated Hardhat 2.28.6 and Forge 1.7.1 projects using declared dependencies only. Hardhat 2's root-only Solidity resolver is handled by narrowly hoisting the package's declared OpenZeppelin dependency in that fixture.

## Compatibility review

All public ABI, selectors, events, errors, storage, enums, ERC165 results, metadata-stripped opcodes, and runtime sizes are unchanged. The only reviewed differences are four raw metadata-bearing hashes from the canonical source path and a one-gas snapshot shift. The policy is baseline-hash-bound, cannot waive public compatibility fields, and requires checked-in opcode/EIP-170 evidence.

## Validation

- frozen pnpm install
- Hardhat: 89/89
- Forge: 15/15
- exact compatibility policy: 5/5 reviewed differences
- package tarball: 19/19 files
- clean Hardhat and Forge consumers
- TypeScript type checking and Solidity linting
- audit ratchet and exotic-source allowlist
