### PR TITLE
build: upgrade OpenZeppelin to 4.9.6

### DIFF
--- a/compatibility/evidence/stage-05-openzeppelin-4-9-6.json
+++ b/compatibility/evidence/stage-05-openzeppelin-4-9-6.json
@@ -1,0 +1,118 @@
+{
+  "schemaVersion": 1,
+  "candidate": "stage-05-openzeppelin-4-9-6",
+  "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+  "mode": "metadata-stripped-equality",
+  "contracts": {
+    "contracts/Wrapper.sol:Wrapper": {
+      "creationBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x416c8a2c12a674cac0f472442830a4f0cc581e118bd7c079846886d91764d03a",
+          "candidate": "0xb5b7c8f622fd56db73f2afc48389ee3681bc1135f6436c9c730e606e6aae0a4e",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0x84629a1d952a89bf833987a3afbcb7ef729ea067994a4798e2b083cc35f3a4dd",
+          "candidate": "0x84629a1d952a89bf833987a3afbcb7ef729ea067994a4798e2b083cc35f3a4dd",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 21964,
+          "candidate": 21964,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "43e3e531d71c6643b1af58cc02dd1e2a28f70bb94eaab0438ba3b2b394dabc25",
+          "candidateSha256": "43e3e531d71c6643b1af58cc02dd1e2a28f70bb94eaab0438ba3b2b394dabc25",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "runtimeBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x96b05a8bcf117adb28ff88a6321d29eb0170ad45f1a58525c6f7e09876d96a0a",
+          "candidate": "0xd783e7a5deb3422621582ff2f12dcc7bef28820036032967b56ff1b89c16a51c",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0x7abb1c8490e30458c1bddf3280a3408bcc9dfd498abdb2735b7c5f8080b6cd8e",
+          "candidate": "0x7abb1c8490e30458c1bddf3280a3408bcc9dfd498abdb2735b7c5f8080b6cd8e",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 21931,
+          "candidate": 21931,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "4c36f6aed0574adcc6e2e73c24be7b5fc90ae1b9be490dc05ffe237a9adcce19",
+          "candidateSha256": "4c36f6aed0574adcc6e2e73c24be7b5fc90ae1b9be490dc05ffe237a9adcce19",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "eip170": {
+        "limitBytes": 24576,
+        "baselineRuntimeSizeBytes": 21984,
+        "candidateRuntimeSizeBytes": 21984,
+        "baselineWithinLimit": true,
+        "candidateWithinLimit": true
+      }
+    },
+    "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership": {
+      "creationBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x3814717bd105739a08051b8e27479b2ec7e8ccea70b28449262e91560577fb8d",
+          "candidate": "0xdc1bd8afbd139c7a99e27c9e213b4b0f326d2835eb24fb279bffe9786ff1a19c",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0x0e8a161965fd0cdde6ec436cc8a556a715f2aee602bb51f147c157daf357c6fe",
+          "candidate": "0x0e8a161965fd0cdde6ec436cc8a556a715f2aee602bb51f147c157daf357c6fe",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 16071,
+          "candidate": 16071,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "01442210ea172bbd50dacfd035ad307bd52678a342f2180f97321d38a812267b",
+          "candidateSha256": "01442210ea172bbd50dacfd035ad307bd52678a342f2180f97321d38a812267b",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "runtimeBytecode": {
+        "rawKeccak256": {
+          "baseline": "0x27fe492cdb1f8b86839558deec3186ee0998b501dbdc5960d01bfd71a0baf735",
+          "candidate": "0x47947e7d863d2448739b0e934d9c426cb53ddd1ede5815e6abbf948501b8ef3b",
+          "changed": true
+        },
+        "metadataStrippedKeccak256": {
+          "baseline": "0xa8d6f6cb7f7a3e72b471fdf442f01a16177aaa4c305d2e00a149fad04ab9d957",
+          "candidate": "0xa8d6f6cb7f7a3e72b471fdf442f01a16177aaa4c305d2e00a149fad04ab9d957",
+          "equal": true
+        },
+        "metadataStrippedSizeBytes": {
+          "baseline": 16039,
+          "candidate": 16039,
+          "equal": true
+        },
+        "metadataStrippedOpcodes": {
+          "baselineSha256": "a203f4e92cf30f0856473a7530df35bc9fa45a7a6e936000630a26fd82a0508e",
+          "candidateSha256": "a203f4e92cf30f0856473a7530df35bc9fa45a7a6e936000630a26fd82a0508e",
+          "equal": true,
+          "diff": []
+        }
+      },
+      "eip170": {
+        "limitBytes": 24576,
+        "baselineRuntimeSizeBytes": 16092,
+        "candidateRuntimeSizeBytes": 16092,
+        "baselineWithinLimit": true,
+        "candidateWithinLimit": true
+      }
+    }
+  }
+}

--- a/compatibility/reviewed-differences.json
+++ b/compatibility/reviewed-differences.json
@@ -1,43 +1,43 @@
 {
   "schemaVersion": 1,
-  "candidate": "stage-04-package-canonical-openzeppelin",
-  "policy": "stage-04-source-path-metadata-and-gas",
+  "candidate": "stage-05-openzeppelin-4-9-6",
+  "policy": "stage-05-openzeppelin-4-9-6-metadata-bytecode",
   "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
   "allowedDifferences": [
     {
       "path": "$.contracts.contracts/Wrapper.sol:Wrapper.creationBytecode.keccak256",
       "baselineValue": "0x416c8a2c12a674cac0f472442830a4f0cc581e118bd7c079846886d91764d03a",
-      "candidateValue": "0xfcc3941bd9ef5acf1bcfed42c166f53e0b340ca7b26499ee91965bd9cc99b8cf",
-      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped creation bytecode is identical."
+      "candidateValue": "0xb5b7c8f622fd56db73f2afc48389ee3681bc1135f6436c9c730e606e6aae0a4e",
+      "reason": "OpenZeppelin 4.9.6 changes dependency source metadata only; the metadata-stripped creation opcodes, hash, and size are identical."
     },
     {
       "path": "$.contracts.contracts/Wrapper.sol:Wrapper.runtimeBytecode.keccak256",
       "baselineValue": "0x96b05a8bcf117adb28ff88a6321d29eb0170ad45f1a58525c6f7e09876d96a0a",
-      "candidateValue": "0x5ed01b3812ffb1828e17f2175bb6eb506e16adf7054e24da74cc832b77d223d0",
-      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped runtime bytecode is identical."
+      "candidateValue": "0xd783e7a5deb3422621582ff2f12dcc7bef28820036032967b56ff1b89c16a51c",
+      "reason": "OpenZeppelin 4.9.6 changes dependency source metadata only; the metadata-stripped runtime opcodes, hash, and size are identical."
     },
     {
       "path": "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.creationBytecode.keccak256",
       "baselineValue": "0x3814717bd105739a08051b8e27479b2ec7e8ccea70b28449262e91560577fb8d",
-      "candidateValue": "0xbf1ed95e61438be3f54c91737b204a86d145f9b4abc8132189e072fa32fe6364",
-      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped creation bytecode is identical."
+      "candidateValue": "0xdc1bd8afbd139c7a99e27c9e213b4b0f326d2835eb24fb279bffe9786ff1a19c",
+      "reason": "OpenZeppelin 4.9.6 changes dependency source metadata only; the metadata-stripped creation opcodes, hash, and size are identical."
     },
     {
       "path": "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.runtimeBytecode.keccak256",
       "baselineValue": "0x27fe492cdb1f8b86839558deec3186ee0998b501dbdc5960d01bfd71a0baf735",
-      "candidateValue": "0x21d919cfe4d73eff24a7b139480d16336212b72de61819df86a278a94d23d884",
-      "reason": "The canonical OpenZeppelin source-unit path changes compiler metadata only; metadata-stripped runtime bytecode is identical."
+      "candidateValue": "0x47947e7d863d2448739b0e934d9c426cb53ddd1ede5815e6abbf948501b8ef3b",
+      "reason": "OpenZeppelin 4.9.6 changes dependency source metadata only; the metadata-stripped runtime opcodes, hash, and size are identical."
     },
     {
       "path": "$.gasSnapshot.entries[11]",
       "baselineValue": "RemittanceTest:test_withdrawOutstandingRemittance(uint256) (runs: 256, μ: 29909, ~: 29922)",
       "candidateValue": "RemittanceTest:test_withdrawOutstandingRemittance(uint256) (runs: 256, μ: 29908, ~: 29921)",
-      "reason": "The fixed-seed Forge snapshot changed by one gas in both mean and median; metadata-stripped production bytecode and behavior are unchanged."
+      "reason": "The fixed-seed snapshot is one gas lower in mean and median; production opcodes and behavior remain unchanged."
     }
   ],
   "opcodeEvidence": {
     "mode": "metadata-stripped-equality",
-    "path": "compatibility/evidence/stage-04-package-canonical-openzeppelin.json",
+    "path": "compatibility/evidence/stage-05-openzeppelin-4-9-6.json",
     "contracts": [
       "contracts/Wrapper.sol:Wrapper",
       "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "web3": "1.7.1"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "4.5.0"
+    "@openzeppelin/contracts": "4.9.6"
   },
   "packageManager": "pnpm@11.13.1",
   "private": false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
   .:
     dependencies:
       '@openzeppelin/contracts':
-        specifier: 4.5.0
-        version: 4.5.0
+        specifier: 4.9.6
+        version: 4.9.6
     devDependencies:
       '@ethersproject/abi':
         specifier: 5.6.0
@@ -434,8 +434,8 @@ packages:
   '@openzeppelin/contract-loader@0.6.3':
     resolution: {integrity: sha512-cOFIjBjwbGgZhDZsitNgJl0Ye1rd5yu/Yx5LMgeq3u0ZYzldm4uObzHDFq4gjDdoypvyORjjJa3BlFA7eAnVIg==}
 
-  '@openzeppelin/contracts@4.5.0':
-    resolution: {integrity: sha512-fdkzKPYMjrRiPK6K4y64e6GzULR7R7RwxSigHS8DDp7aWDeoReqsQI+cxHV1UuhAqX69L1lAaWDxenfP+xiqzA==}
+  '@openzeppelin/contracts@4.9.6':
+    resolution: {integrity: sha512-xSmezSupL+y9VkHZJGDoCBpmnB2ogM13ccaYDWqJTfS3dbuHkgjuwDFUmaFauBCboQMGB/S5UqUl2y54X99BmA==}
 
   '@openzeppelin/test-helpers@0.5.15':
     resolution: {integrity: sha512-10fS0kyOjc/UObo9iEWPNbC6MCeiQ7z97LDOJBj68g+AAs5pIGEI2h3V6G9TYTIq8VxOdwMQbfjKrx7Y3YZJtA==}
@@ -5908,7 +5908,7 @@ snapshots:
       find-up: 4.1.0
       fs-extra: 8.1.0
 
-  '@openzeppelin/contracts@4.5.0': {}
+  '@openzeppelin/contracts@4.9.6': {}
 
   '@openzeppelin/test-helpers@0.5.15(bn.js@4.12.0)(bufferutil@4.0.6)(supports-color@8.1.1)(utf-8-validate@5.0.9)':
     dependencies:

--- a/scripts/compatibility.js
+++ b/scripts/compatibility.js
@@ -45,6 +45,13 @@ const STAGE_04_RAW_BYTECODE_HASH_PATHS = new Set([
   "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.runtimeBytecode.keccak256",
 ]);
 
+const STAGE_05_RAW_BYTECODE_HASH_PATHS = new Set([
+  "$.contracts.contracts/Wrapper.sol:Wrapper.creationBytecode.keccak256",
+  "$.contracts.contracts/Wrapper.sol:Wrapper.runtimeBytecode.keccak256",
+  "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.creationBytecode.keccak256",
+  "$.contracts.contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership.runtimeBytecode.keccak256",
+]);
+
 const REVIEW_POLICIES = Object.freeze({
   "stage-04-source-path-metadata-and-gas": Object.freeze({
     candidate: "stage-04-package-canonical-openzeppelin",
@@ -63,6 +70,23 @@ const REVIEW_POLICIES = Object.freeze({
       );
     },
   }),
+  "stage-05-openzeppelin-4-9-6-metadata-bytecode": Object.freeze({
+    candidate: "stage-05-openzeppelin-4-9-6",
+    requiredOpcodeEvidence: Object.freeze({
+      mode: "metadata-stripped-equality",
+      path: "compatibility/evidence/stage-05-openzeppelin-4-9-6.json",
+      contracts: Object.freeze([
+        "contracts/Wrapper.sol:Wrapper",
+        "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership",
+      ]),
+    }),
+    permits(reviewPath) {
+      return (
+        STAGE_05_RAW_BYTECODE_HASH_PATHS.has(reviewPath) ||
+        reviewPath === "$.gasSnapshot.entries[11]"
+      );
+    },
+  }),
 });
 
 const NON_WAIVABLE_REVIEW_PATHS = [
@@ -74,6 +98,10 @@ const NON_WAIVABLE_REVIEW_PATHS = [
   {
     name: "interfaces, enums, or ERC165 results",
     pattern: /^\$\.(?:interfaces|enums|erc165)(?:\.|\[|$)/,
+  },
+  {
+    name: "the executed behavior-test inventory",
+    pattern: /^\$\.tests(?:\.|\[|$)/,
   },
 ];
 

--- a/tests/Wrapper.ts
+++ b/tests/Wrapper.ts
@@ -387,30 +387,88 @@ describe("Wrapper.sol", async function () {
       });
 
       it("when non-owner tries to wrap", async function () {
+        const tokenId = TOKENS.ONE;
+        const wrappedId = wrappedTokenId(testNFTContract.address, tokenId);
+        const nftOwnerBefore = await testNFTContract.ownerOf(tokenId);
+        const nftOwnerBalanceBefore = await testNFTContract.balanceOf(
+          nftOwnerBefore
+        );
+        const wrapperEtherBalanceBefore = await provider.getBalance(
+          wrapperContract.address
+        );
+        const aliceWrappedBalanceBefore = await wrapperContract.balanceOf(
+          alice.address
+        );
+
         await expect(
           alice.contract.wrap(
             testNFTContract.address,
-            TOKENS.ONE,
+            tokenId,
             wrapValuation,
             deployer.address,
             taxConfig.taxRate,
             taxConfig.collectionFrequency,
             { value: ETH1 }
           )
-        ).to.be.revertedWith(ERC721ErrorMessages.NOT_APPROVED);
+        ).to.be.reverted;
+
+        expect(await testNFTContract.ownerOf(tokenId)).to.equal(nftOwnerBefore);
+        expect(await testNFTContract.balanceOf(nftOwnerBefore)).to.equal(
+          nftOwnerBalanceBefore
+        );
+        expect(await provider.getBalance(wrapperContract.address)).to.equal(
+          wrapperEtherBalanceBefore
+        );
+        expect(await wrapperContract.balanceOf(alice.address)).to.equal(
+          aliceWrappedBalanceBefore
+        );
+        await expect(wrapperContract.ownerOf(wrappedId)).to.be.revertedWith(
+          ERC721ErrorMessages.OWNER_NONEXISTENT_TOKEN
+        );
       });
 
       it("if owner has not approved wrapper", async function () {
+        const tokenId = TOKENS.ONE;
+        const wrappedId = wrappedTokenId(testNFTContract.address, tokenId);
+        const nftOwnerBefore = await testNFTContract.ownerOf(tokenId);
+        const nftOwnerBalanceBefore = await testNFTContract.balanceOf(
+          nftOwnerBefore
+        );
+        const wrapperEtherBalanceBefore = await provider.getBalance(
+          wrapperContract.address
+        );
+        const deployerWrappedBalanceBefore = await wrapperContract.balanceOf(
+          deployer.address
+        );
+        const approvalBefore = await testNFTContract.getApproved(tokenId);
+
         await expect(
           deployer.contract.wrap(
             testNFTContract.address,
-            TOKENS.ONE,
+            tokenId,
             wrapValuation,
             deployer.address,
             taxConfig.taxRate,
             taxConfig.collectionFrequency
           )
-        ).to.be.revertedWith(ERC721ErrorMessages.NOT_APPROVED);
+        ).to.be.reverted;
+
+        expect(await testNFTContract.ownerOf(tokenId)).to.equal(nftOwnerBefore);
+        expect(await testNFTContract.balanceOf(nftOwnerBefore)).to.equal(
+          nftOwnerBalanceBefore
+        );
+        expect(await testNFTContract.getApproved(tokenId)).to.equal(
+          approvalBefore
+        );
+        expect(await provider.getBalance(wrapperContract.address)).to.equal(
+          wrapperEtherBalanceBefore
+        );
+        expect(await wrapperContract.balanceOf(deployer.address)).to.equal(
+          deployerWrappedBalanceBefore
+        );
+        await expect(wrapperContract.ownerOf(wrappedId)).to.be.revertedWith(
+          ERC721ErrorMessages.OWNER_NONEXISTENT_TOKEN
+        );
       });
 
       it("if operator is beneficiary and included deposit", async function () {

--- a/tests/helpers/types.ts
+++ b/tests/helpers/types.ts
@@ -5,7 +5,6 @@ enum TOKENS {
 }
 
 enum ERC721ErrorMessages {
-  NOT_APPROVED = "ERC721: transfer caller is not owner nor approved",
   NONEXISTENT_TOKEN = "ERC721: query for nonexistent token",
   OWNER_NONEXISTENT_TOKEN = "ERC721: owner query for nonexistent token",
 }


### PR DESCRIPTION
<!-- modernization-chronology:start -->
## Modernization chronology

- **Phase:** Stage 5 — OpenZeppelin 4.9.6 compatibility bridge
- **Predecessor:** [#84 — package-boundary repair](https://github.com/721labs/partial-common-ownership/pull/84)
- **This checkpoint:** [#85](https://github.com/721labs/partial-common-ownership/pull/85) — merged at [fb18407b04e0c2ecc47435721150fb74e8189fe0](https://github.com/721labs/partial-common-ownership/commit/fb18407b04e0c2ecc47435721150fb74e8189fe0) on 2026-07-16T15:20:29Z
- **Successor:** [#86 — complete Forge behavior parity](https://github.com/721labs/partial-common-ownership/pull/86)
- **Relationship:** Historical merge order: this isolated the OpenZeppelin 4.x change before test-oracle expansion.
<!-- modernization-chronology:end -->

## Summary
- upgrade only @openzeppelin/contracts from 4.5.0 to exact 4.9.6
- decouple two TestNFT checks from upstream OpenZeppelin wording while proving full rollback
- record immutable compatibility evidence for metadata-only bytecode hash changes

## Safety gates
- 89/89 Hardhat and 15/15 Forge tests
- ABI, selectors, events, errors, storage, interfaces, enums, and ERC165 unchanged
- metadata-stripped opcodes and bytecode sizes unchanged; EIP-170 safe
- package consumers pass with exact OpenZeppelin 4.9.6
- frozen install, typecheck, solhint, lock validation, and audit ratchet pass
- independent final audit found no blockers

No production contract source changed.
