### PR TITLE
build(deps): migrate interoperability smokes to ethers 6

### DIFF
--- a/compatibility/README.md
+++ b/compatibility/README.md
@@ -268,6 +268,42 @@ node scripts/compatibility.js check
 node scripts/compatibility.js stage-11-negative-probes
 ```
 
+Stage 12a uses the named `stage-12a-ethers-6-stage-11-equality` policy. It
+anchors the merged Stage 11 commit
+`c84870955d77e82e91ed70591f010233675a6880`, its exact evidence and review
+digests, and reconstructs the Stage 11 production bytecode, metadata-stripped
+opcodes, sizes, compiler identity, 15-entry legacy gas inventory, 12 key-flow
+gas results, and active 3-Hardhat plus 140-Forge test inventory before
+comparison.
+
+The bridge changes only JavaScript tooling: direct ethers becomes exact
+6.17.0, `@nomicfoundation/hardhat-ethers` 3.1.3 is activated under unchanged
+Hardhat 2.28.6, and the three interoperability smokes are migrated to ethers 6
+without changing their reporter titles or behavior. The legacy NomicLabs
+ethers, Waffle, and ethers-v5 TypeChain hooks remain installed but are not
+loaded or invoked. Their grouped removal remains isolated to Stage 12b; the
+resulting peer warning is recorded and is not suppressed. The unrelated Web3
+plugin remains unchanged.
+
+The Stage 12a tooling inventory binds the new smoke source, package and lock,
+Hardhat config and declaration file, and TypeScript scope while retaining the
+exact Stage 11 inventory digest and old smoke-source digest as provenance. No
+compatibility-manifest difference is reviewable: production sources and import
+closure, runtime dependencies, compiler settings, ABI, selectors, events,
+errors, storage, interfaces, enum ordinals, ERC165 answers, revert callsites,
+bytecode, opcodes, sizes, gas, and all 143 active test identifiers must remain
+exactly equal to Stage 11.
+
+Reproduce the Stage 12a review, evidence, gate, and adversarial policy probes
+with:
+
+```console
+node scripts/compatibility.js write-stage-12a-review
+node scripts/compatibility.js write-evidence
+node scripts/compatibility.js check
+node scripts/compatibility.js stage-12a-negative-probes
+```
+
 The original baseline predated explicit revert-literal extraction.
 `project-revert-strings.json` is a SHA-256-bound supplement derived from the
 unchanged production sources at the recorded baseline commit. It binds all 35

--- a/compatibility/evidence/stage-12a-ethers-6.json
+++ b/compatibility/evidence/stage-12a-ethers-6.json
@@ -1,0 +1,945 @@
+{
+  "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+  "candidate": "stage-12a-ethers-6",
+  "hardCompatibility": {
+    "compilerSettings": {
+      "equal": true,
+      "sha256": "b7982e960bba84395082f2d7161fde9ce5a16f709623676b308065509484c7dd"
+    },
+    "contracts": {
+      "contracts/Wrapper.sol:Wrapper": {
+        "abi": {
+          "equal": true,
+          "sha256": "58641c81e3de2df24c5b453d326c764e1179220ad22d9ecc78cea61780b013b0"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "8b2221f5c36a0c23b4ea0934ade8164581cb157241a3d2f00e27f1c40e456633"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "e9b9291d1a85809068aef324f922e2f2be3b69c332737e983daffb07b4a53647"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "6c96a23e64194cb565af91ebc82f44371f7d144392e002a6d793bb42a7736c7a"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "ca57141d71c85580db97654ce8ee71fae1ec0ab4311da22b3174e65fb60b4740"
+        }
+      },
+      "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership": {
+        "abi": {
+          "equal": true,
+          "sha256": "73e541c82c80dce85cb5881a03498136b78c9823ddd8597f457080116302453a"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "8b2221f5c36a0c23b4ea0934ade8164581cb157241a3d2f00e27f1c40e456633"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "9c85551213eed0d74a4c1a2a353857446cbee45f9104d7fd62fafd5c1be992fb"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "4731b63a28a9f52c74b2c4a33e275065ab33f77dd40bc67b3a62786b18c6a411"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "b6f31762e0e25890dab1e2cc0f90b59601bbbd39274614896a29f89a372709b8"
+        }
+      },
+      "contracts/token/modules/interfaces/IBeneficiary.sol:IBeneficiary": {
+        "abi": {
+          "equal": true,
+          "sha256": "208977a707ff530c243ce0126c48742dd107c23fd124c26ddb3b6603653257da"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "35355acd8f91ce51a27db7c56d644350480fbe3e03b05c8c2502eb078341ac5f"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "5007e3b784841c1839d50e1c7c327054fd93a236126542d5218ef7d82f30c563"
+        }
+      },
+      "contracts/token/modules/interfaces/ILease.sol:ILease": {
+        "abi": {
+          "equal": true,
+          "sha256": "1c308860ac89c9a081aa27a5e327ba0b9b154298f06f3ef2814b326ec4e8ca37"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "e760b072b127f239f5f58a4a586efb569f9ca878686df829c17f4775afc4548a"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "5007e3b784841c1839d50e1c7c327054fd93a236126542d5218ef7d82f30c563"
+        }
+      },
+      "contracts/token/modules/interfaces/IRemittance.sol:IRemittance": {
+        "abi": {
+          "equal": true,
+          "sha256": "43b794b5e465376ded9d6960c72693e2a08f09700d9930fe6ccc392be579053d"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "ad568db3632233a2c772299fff9746241b9a3a4d40c4080dbd253ce6c52efa10"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "5007e3b784841c1839d50e1c7c327054fd93a236126542d5218ef7d82f30c563"
+        }
+      },
+      "contracts/token/modules/interfaces/ITaxation.sol:ITaxation": {
+        "abi": {
+          "equal": true,
+          "sha256": "79377855a6e06cba6e2dc1974cc87f6f2e10e18d8bac29d8be30e4def1ef47af"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "b9b67cc5b016c1db267bd8395285a87e9996959da21b6553e0ce6f4a302f8376"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "5007e3b784841c1839d50e1c7c327054fd93a236126542d5218ef7d82f30c563"
+        }
+      },
+      "contracts/token/modules/interfaces/IValuation.sol:IValuation": {
+        "abi": {
+          "equal": true,
+          "sha256": "518777dff270449e9043dcc2799a18c53ba4eebee8623ca7cbfd9d92bc48e078"
+        },
+        "errors": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "events": {
+          "equal": true,
+          "sha256": "37517e5f3dc66819f61f5a7bb8ace1921282415f10551d2defa5c3eb0985b570"
+        },
+        "functions": {
+          "equal": true,
+          "sha256": "1f1e43b88327d9bc7c6e5dcd004b453657c598a2fcc4d31bbd694c750d8683b5"
+        },
+        "storageLayout": {
+          "equal": true,
+          "sha256": "5007e3b784841c1839d50e1c7c327054fd93a236126542d5218ef7d82f30c563"
+        }
+      }
+    },
+    "enums": {
+      "equal": true,
+      "sha256": "d8825043487a38b00222b547329d1905a1142f6c80b8b4764d2db7697693f628"
+    },
+    "erc165": {
+      "equal": true,
+      "sha256": "357e067484da1a8a65e64868b2fda486200c575983af64817b9ccf5e6d24287f"
+    },
+    "interfaces": {
+      "equal": true,
+      "sha256": "5b5d1f2625e9b544ced655510b8302263afd9766dc55b8aee84dd3daae1cc0d0"
+    },
+    "parityFiles": {
+      "compatibility/parity-map.json": "72f66deac5693d553a681afa755856cc87f2d52d4b109938862ba731da9443b4",
+      "compatibility/parity/cohort-0-existing-forge.json": "3384ae9039fad21bb7800d61f181bd4ca6b68a8e1e8525815c3cc8ecd434df69",
+      "compatibility/parity/cohort-1-pco-read-tax.json": "632c07354ab5f4e0d71290e2631da59bacad8cc3c0bc1d22cc129674098891fc",
+      "compatibility/parity/cohort-2-pco-mutations.json": "47b93d5ecd3734b09533c8af0c514274ad4ff3c90185a6724364060bf5eef5c1",
+      "compatibility/parity/cohort-3-wrapper.json": "4932bd7dd4da1cf55b2723e98cbe865737c9e735528ad70f05f8de85c2baecca",
+      "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a"
+    },
+    "projectRevertStrings": {
+      "count": 37,
+      "equal": true,
+      "sha256": "a5d2ca753e5d123ac138771623e491360c87e39e8d148f8e871a5d2b9fb73008"
+    },
+    "tests": {
+      "forge": {
+        "count": 140,
+        "mappedBehaviorCount": 104,
+        "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173",
+        "safetyCount": 36
+      },
+      "hardhat": {
+        "count": 3,
+        "names": [
+          "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+          "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+          "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+        ],
+        "namesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f"
+      },
+      "toolingInventory": {
+        "activeHardhat": {
+          "count": 3,
+          "names": [
+            "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+            "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+            "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+          ],
+          "sourcePath": "tests/Interoperability.smoke.ts",
+          "sourceSha256": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350"
+        },
+        "candidate": "stage-12a-ethers-6",
+        "forge": {
+          "count": 140,
+          "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173"
+        },
+        "inheritedStage11": {
+          "hardhatNamesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f",
+          "inventoryPath": "compatibility/stage-11-hardhat-smoke-inventory.json",
+          "inventorySha256": "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4",
+          "smokeSourceSha256": "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a"
+        },
+        "parity": {
+          "files": {
+            "compatibility/parity-map.json": "72f66deac5693d553a681afa755856cc87f2d52d4b109938862ba731da9443b4",
+            "compatibility/parity/cohort-0-existing-forge.json": "3384ae9039fad21bb7800d61f181bd4ca6b68a8e1e8525815c3cc8ecd434df69",
+            "compatibility/parity/cohort-1-pco-read-tax.json": "632c07354ab5f4e0d71290e2631da59bacad8cc3c0bc1d22cc129674098891fc",
+            "compatibility/parity/cohort-2-pco-mutations.json": "47b93d5ecd3734b09533c8af0c514274ad4ff3c90185a6724364060bf5eef5c1",
+            "compatibility/parity/cohort-3-wrapper.json": "4932bd7dd4da1cf55b2723e98cbe865737c9e735528ad70f05f8de85c2baecca",
+            "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a"
+          },
+          "mappedBehaviorCount": 104,
+          "safetyCount": 36
+        },
+        "path": "compatibility/stage-12a-ethers6-inventory.json",
+        "schemaVersion": 1,
+        "sha256": "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+        "stage11Checkpoint": "c84870955d77e82e91ed70591f010233675a6880",
+        "tooling": {
+          "ethers": "6.17.0",
+          "files": {
+            "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+            "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+            "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+            "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+            "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+          },
+          "hardhat": "2.28.6",
+          "hardhatEthers": "3.1.3"
+        }
+      },
+      "total": 143
+    }
+  },
+  "inheritedStage11Checkpoint": {
+    "commit": "c84870955d77e82e91ed70591f010233675a6880",
+    "evidence": {
+      "path": "compatibility/evidence/stage-11-foundry-first-cutover.json",
+      "sha256": "0077542e6ac4c5f1af3813ff8e84dcc4d46182f1a8c0b28e290acfae733da412"
+    },
+    "review": {
+      "path": "compatibility/reviewed-differences.json",
+      "sha256": "4dfa67856a3d5d04a1057df5064926a07fd1dcde314b05bbdd1927a3080b7731"
+    }
+  },
+  "keyFlowGasEquality": {
+    "baselinePath": "gas/key-flows.snap",
+    "baselinePolicy": {
+      "absoluteFloorGas": 2000,
+      "percent": 3
+    },
+    "baselineSha256": "c57e387d3a71141ce69078dc051608e8eb1f5bccbddf5745f6d478d709b575f7",
+    "comparisons": [
+      {
+        "baselineGas": 311994,
+        "candidateGas": 313088,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 321353,
+        "name": "PCOMutationParityTest:test_deposit_succeeds_ownerCanDeposit()",
+        "stage11Gas": 313088,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 297540,
+        "candidateGas": 298684,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 306466,
+        "name": "PCOMutationParityTest:test_exit_succeeds_withdrawsEntireDeposit()",
+        "stage11Gas": 298684,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 311281,
+        "candidateGas": 312351,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 320619,
+        "name": "PCOMutationParityTest:test_selfAssess_succeeds_ownerIncreasesValuation()",
+        "stage11Gas": 312351,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 201883,
+        "candidateGas": 201930,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 207939,
+        "name": "PCOMutationParityTest:test_takeoverLease_succeeds_firstPurchaseFromContract()",
+        "stage11Gas": 201930,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 366657,
+        "candidateGas": 367097,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 377656,
+        "name": "PCOMutationParityTest:test_takeoverLease_succeeds_purchaseFromCurrentOwner()",
+        "stage11Gas": 367097,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 412121,
+        "candidateGas": 412840,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 424484,
+        "name": "PCOMutationParityTest:test_takeoverLease_succeeds_purchaseFromForeclosure()",
+        "stage11Gas": 412840,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 320385,
+        "candidateGas": 321433,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 329996,
+        "name": "PCOMutationParityTest:test_withdrawDeposit_succeeds_expectedAmount()",
+        "stage11Gas": 321433,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 297434,
+        "candidateGas": 299397,
+        "equal": true,
+        "group": "PartialCommonOwnership",
+        "maximumGas": 306357,
+        "name": "PCOReadTaxParityTest:test_parity_013_collectTax_collectsAfterTenMinutes()",
+        "stage11Gas": 299397,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 384375,
+        "candidateGas": 394324,
+        "equal": true,
+        "group": "Wrapper",
+        "maximumGas": 395906,
+        "name": "WrapperParityTest:test_unwrap_afterBeneficiaryWrap()",
+        "stage11Gas": 394324,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 549977,
+        "candidateGas": 557316,
+        "equal": true,
+        "group": "Wrapper",
+        "maximumGas": 566476,
+        "name": "WrapperParityTest:test_unwrap_afterNonBeneficiaryWrap()",
+        "stage11Gas": 557316,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 618910,
+        "candidateGas": 626621,
+        "equal": true,
+        "group": "Wrapper",
+        "maximumGas": 637477,
+        "name": "WrapperParityTest:test_unwrap_collectsTaxAndReturnsDeposit()",
+        "stage11Gas": 626621,
+        "withinBaselineLimit": true
+      },
+      {
+        "baselineGas": 413157,
+        "candidateGas": 385662,
+        "equal": true,
+        "group": "Wrapper",
+        "maximumGas": 425551,
+        "name": "WrapperParityTest:test_wrap_tokenOwnerCanWrap()",
+        "stage11Gas": 385662,
+        "withinBaselineLimit": true
+      }
+    ],
+    "fuzzSeed": "0x721"
+  },
+  "legacyGasEquality": {
+    "candidateEntriesSha256": "fa60702147fc72d701554d1956429bbef76c8c7186a08ee06fa06f01ade2da7d",
+    "equal": true,
+    "fuzzSeed": "0x721",
+    "inventoryCount": 15,
+    "stage11EntriesSha256": "fa60702147fc72d701554d1956429bbef76c8c7186a08ee06fa06f01ade2da7d"
+  },
+  "mode": "stage-12a-stage-11-production-equality",
+  "productionEquality": {
+    "compiler": {
+      "longVersion": "0.8.36+commit.8a079791",
+      "settingsSha256": "b7982e960bba84395082f2d7161fde9ce5a16f709623676b308065509484c7dd",
+      "version": "0.8.36"
+    },
+    "contracts": {
+      "contracts/Wrapper.sol:Wrapper": {
+        "creationBytecode": {
+          "candidate": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0xb233917e1fa224641a01e8c9fce9b04abeacd86f0e34680631748fec76d00a30",
+            "metadataStrippedOpcodesSha256": "b6cbcd4d450423db952e6ab2ecb92feacd0b55bd96aef04ef9cc3029884de7a2",
+            "metadataStrippedSizeBytes": 22300,
+            "rawKeccak256": "0xdb202e3981d93a859cdf7facab93b56e4f926fe495d04abff07b74d1ab3c0bf0",
+            "rawSizeBytes": 22353
+          },
+          "equal": true,
+          "opcodeInstructionCount": 10954,
+          "stage11": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0xb233917e1fa224641a01e8c9fce9b04abeacd86f0e34680631748fec76d00a30",
+            "metadataStrippedOpcodesSha256": "b6cbcd4d450423db952e6ab2ecb92feacd0b55bd96aef04ef9cc3029884de7a2",
+            "metadataStrippedSizeBytes": 22300,
+            "rawKeccak256": "0xdb202e3981d93a859cdf7facab93b56e4f926fe495d04abff07b74d1ab3c0bf0",
+            "rawSizeBytes": 22353
+          }
+        },
+        "eip170": {
+          "candidateRuntimeSizeBytes": 22322,
+          "candidateWithinLimit": true,
+          "equal": true,
+          "limitBytes": 24576,
+          "stage11RuntimeSizeBytes": 22322
+        },
+        "runtimeBytecode": {
+          "candidate": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0x7b75f790a8f49d28a3a6630b6440319a85b2b4ea7334e0541902de557b332f21",
+            "metadataStrippedOpcodesSha256": "a05e38b7756afd9dc7a74f08745e0ce623880e0682f293ece04dc26514beef41",
+            "metadataStrippedSizeBytes": 22269,
+            "rawKeccak256": "0x037291189f7b8a51cfb8f98b83517e98539c37fa434ee65c6f6453bb71318d2e",
+            "rawSizeBytes": 22322
+          },
+          "equal": true,
+          "opcodeInstructionCount": 10933,
+          "stage11": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0x7b75f790a8f49d28a3a6630b6440319a85b2b4ea7334e0541902de557b332f21",
+            "metadataStrippedOpcodesSha256": "a05e38b7756afd9dc7a74f08745e0ce623880e0682f293ece04dc26514beef41",
+            "metadataStrippedSizeBytes": 22269,
+            "rawKeccak256": "0x037291189f7b8a51cfb8f98b83517e98539c37fa434ee65c6f6453bb71318d2e",
+            "rawSizeBytes": 22322
+          }
+        }
+      },
+      "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership": {
+        "creationBytecode": {
+          "candidate": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0x0e4d2924927f4ac1a3d527344a408765800202bfcf24c8c7cd2cf3e088ea5bf9",
+            "metadataStrippedOpcodesSha256": "b2447a57ae59683de03cbcf9a6eeaec54e952402eefab5c445a4272732706c2b",
+            "metadataStrippedSizeBytes": 16340,
+            "rawKeccak256": "0x2f4aac7e45c14b4bd099b2bb4d0117c077570f0f1bdd30fe4ef61d3c88a124af",
+            "rawSizeBytes": 16393
+          },
+          "equal": true,
+          "opcodeInstructionCount": 8060,
+          "stage11": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0x0e4d2924927f4ac1a3d527344a408765800202bfcf24c8c7cd2cf3e088ea5bf9",
+            "metadataStrippedOpcodesSha256": "b2447a57ae59683de03cbcf9a6eeaec54e952402eefab5c445a4272732706c2b",
+            "metadataStrippedSizeBytes": 16340,
+            "rawKeccak256": "0x2f4aac7e45c14b4bd099b2bb4d0117c077570f0f1bdd30fe4ef61d3c88a124af",
+            "rawSizeBytes": 16393
+          }
+        },
+        "eip170": {
+          "candidateRuntimeSizeBytes": 16362,
+          "candidateWithinLimit": true,
+          "equal": true,
+          "limitBytes": 24576,
+          "stage11RuntimeSizeBytes": 16362
+        },
+        "runtimeBytecode": {
+          "candidate": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0x1a9d3b31ab2c4772935c9f0794c75ef5909551948999a6977cea12f4872a319b",
+            "metadataStrippedOpcodesSha256": "938ea23081b2903035c1a7df77b86551b6c0447aed56548478462fdefb81fda7",
+            "metadataStrippedSizeBytes": 16309,
+            "rawKeccak256": "0xdd3b276639e0b97a93744e77f3608c7e080b2cdad97a349ca94004590d4d6072",
+            "rawSizeBytes": 16362
+          },
+          "equal": true,
+          "opcodeInstructionCount": 8039,
+          "stage11": {
+            "metadataBytes": 53,
+            "metadataStrippedKeccak256": "0x1a9d3b31ab2c4772935c9f0794c75ef5909551948999a6977cea12f4872a319b",
+            "metadataStrippedOpcodesSha256": "938ea23081b2903035c1a7df77b86551b6c0447aed56548478462fdefb81fda7",
+            "metadataStrippedSizeBytes": 16309,
+            "rawKeccak256": "0xdd3b276639e0b97a93744e77f3608c7e080b2cdad97a349ca94004590d4d6072",
+            "rawSizeBytes": 16362
+          }
+        }
+      }
+    }
+  },
+  "schemaVersion": 1,
+  "toolingAndTestMigration": {
+    "boundFiles": {
+      "compatibility/README.md": "cccac2d4fb89015cdbe20197a9c08d78ecc90c11384d485690b471e42e390df8",
+      "compatibility/stage-12a-ethers6-inventory.json": "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+      "docs/development.md": "ab764805a0d8d4679dca1f6b2043ba3f21ea2b5420d567558719a3d5c2109727",
+      "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+      "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+      "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+      "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+      "scripts/check-parity.js": "540ef384dda01295a357a048290bb89004d3aa64a5e7455b73ff3c08fe37f53a",
+      "tests/Interoperability.smoke.ts": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350",
+      "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+    },
+    "changedPaths": [
+      "compatibility/README.md",
+      "compatibility/evidence/stage-12a-ethers-6.json",
+      "compatibility/reviewed-differences.json",
+      "compatibility/stage-12a-ethers6-inventory.json",
+      "docs/development.md",
+      "hardhat.config.d.ts",
+      "hardhat.config.ts",
+      "package.json",
+      "pnpm-lock.yaml",
+      "scripts/check-parity.js",
+      "scripts/compatibility.js",
+      "tests/Interoperability.smoke.ts",
+      "tsconfig.json"
+    ],
+    "checkpoint": {
+      "commit": "c84870955d77e82e91ed70591f010233675a6880",
+      "evidence": {
+        "path": "compatibility/evidence/stage-11-foundry-first-cutover.json",
+        "sha256": "0077542e6ac4c5f1af3813ff8e84dcc4d46182f1a8c0b28e290acfae733da412"
+      },
+      "review": {
+        "path": "compatibility/reviewed-differences.json",
+        "sha256": "4dfa67856a3d5d04a1057df5064926a07fd1dcde314b05bbdd1927a3080b7731"
+      }
+    },
+    "compatibilityRunnerSha256": "32c083dc668e73a5c5e134389e20a09ef9704bc6836192ec0a9e24d74476c5de",
+    "compilerSources": {
+      "candidateClosureSha256": "38d2428df3ed7472afb28ad76273ea14ed05c89bbfcc165a9540378b9ca317df",
+      "completeSourceHashes": {
+        "@openzeppelin/contracts/token/ERC721/IERC721.sol": "ff0eb9902bf0ac099205615fac90eacf34fae637571b05aab3ea35dea53d5f17",
+        "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol": "eafee3ffdc7cb2fba4bf6bd16fb28f8e5b4679742e81c2ad42a1b1df5c179feb",
+        "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol": "33223782ea652dca413702ce92f9f59d91d758a035065b24bbedb7dc60c63a78",
+        "@openzeppelin/contracts/utils/Context.sol": "847fda5460fee70f56f4200f59b82ae622bb03c79c77e67af010e31b7e2cc5b6",
+        "@openzeppelin/contracts/utils/introspection/ERC165.sol": "61a2b12c96857aaa35f48aeda67a4281637a42494c0b3795be0ae976aa7b3793",
+        "@openzeppelin/contracts/utils/introspection/IERC165.sol": "9055c2994b37dea1a41b7b7926dcb510f05dbe2540b0aafc5fbee9558fffd0ca",
+        "contracts/Wrapper.sol": "4d8766bd7baa0a1bd2b021c0de27a04c59219d86fd0c907973e7873e5b069915",
+        "contracts/test/Blocker.sol": "aca41aa8d3aac9a0470992486b2332ebe60fef1f68733ea1796eb928a11192e9",
+        "contracts/test/PCOInitializationReceiver.sol": "0fe50d69c4878217b6bf772a4d2aff4a8c6129ea418c43bfbc79366f053f588f",
+        "contracts/test/TestNFT.sol": "110fadbf1c0d3052ebd517512596e62d63085137c3c81261271f9da65997c0b6",
+        "contracts/test/TestPCOToken.sol": "2ac57c7f2faf8d0ccb392af85f1f9ef4db7154a5f7ee38df72939d91eee72578",
+        "contracts/test/TestWrapper.sol": "81613e6f1da5e0cb98900809b138492db007019dd8ca80a00ad917effb222ac5",
+        "contracts/token/PartialCommonOwnership.sol": "5429da466a15811ce0196b99b710f247b3d6392c81cce2b84cab5ab83129c825",
+        "contracts/token/modules/Beneficiary.sol": "91e507656ebd6ec2d5ae5dfe2fe24ba0e30cea87b3deb14dd5e6140479e61500",
+        "contracts/token/modules/ERC721.sol": "7bcb9d453294af951005305c25003c0754643c1c53cb3f310436b31931192e1b",
+        "contracts/token/modules/Lease.sol": "269ec676c2a8bdd8148b0e2ce8743da676c220109583df569f95673bfaaac34f",
+        "contracts/token/modules/Remittance.sol": "3b9c9c0efea65e5256c7faad8061342b9764f58d5676550088b587d46d73bcc6",
+        "contracts/token/modules/Taxation.sol": "72aa02e63d76e28e6f04e29ea49e81a764f2211955e032a907fe0a7e524b0027",
+        "contracts/token/modules/Valuation.sol": "10b3450c7a2bc9c0b1f12f774c34abd70338480f908dc77d448d0de425adca02",
+        "contracts/token/modules/interfaces/IBeneficiary.sol": "b65dfa02ee1a1a6d89694323bc5b621f6c5504d8d1ab640a9ae03189fb3dceff",
+        "contracts/token/modules/interfaces/ILease.sol": "6373d8ce3d99fca346278de04dfedaaefc46ed7b4e4812b1b8737a03abbccfa1",
+        "contracts/token/modules/interfaces/IRemittance.sol": "aec91c493f5b6482d97a55031a559ba8084e93c6112e49742dadc1c91af987eb",
+        "contracts/token/modules/interfaces/ITaxation.sol": "78b7663a40929bfd7afc0c4315abf6365287fd17ca9986479c963aedfb28de42",
+        "contracts/token/modules/interfaces/IValuation.sol": "d7fd7c28b9a78a1e194b20f7e1a1c8c0b13b47df237f1c7defa95e45f6201e06"
+      },
+      "equalToStage11": true,
+      "productionImportClosure": {
+        "names": [
+          "@openzeppelin/contracts/token/ERC721/IERC721.sol",
+          "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol",
+          "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol",
+          "@openzeppelin/contracts/utils/Context.sol",
+          "@openzeppelin/contracts/utils/introspection/ERC165.sol",
+          "@openzeppelin/contracts/utils/introspection/IERC165.sol",
+          "contracts/Wrapper.sol",
+          "contracts/token/PartialCommonOwnership.sol",
+          "contracts/token/modules/Beneficiary.sol",
+          "contracts/token/modules/ERC721.sol",
+          "contracts/token/modules/Lease.sol",
+          "contracts/token/modules/Remittance.sol",
+          "contracts/token/modules/Taxation.sol",
+          "contracts/token/modules/Valuation.sol",
+          "contracts/token/modules/interfaces/IBeneficiary.sol",
+          "contracts/token/modules/interfaces/ILease.sol",
+          "contracts/token/modules/interfaces/IRemittance.sol",
+          "contracts/token/modules/interfaces/ITaxation.sol",
+          "contracts/token/modules/interfaces/IValuation.sol"
+        ],
+        "namesSha256": "849e5960d77cb7b77f5136be719b867ed21ef946882220ea82841e700bffe353",
+        "openzeppelin": [
+          "@openzeppelin/contracts/token/ERC721/IERC721.sol",
+          "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol",
+          "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol",
+          "@openzeppelin/contracts/utils/Context.sol",
+          "@openzeppelin/contracts/utils/introspection/ERC165.sol",
+          "@openzeppelin/contracts/utils/introspection/IERC165.sol"
+        ],
+        "sourceHashes": {
+          "@openzeppelin/contracts/token/ERC721/IERC721.sol": "ff0eb9902bf0ac099205615fac90eacf34fae637571b05aab3ea35dea53d5f17",
+          "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol": "eafee3ffdc7cb2fba4bf6bd16fb28f8e5b4679742e81c2ad42a1b1df5c179feb",
+          "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol": "33223782ea652dca413702ce92f9f59d91d758a035065b24bbedb7dc60c63a78",
+          "@openzeppelin/contracts/utils/Context.sol": "847fda5460fee70f56f4200f59b82ae622bb03c79c77e67af010e31b7e2cc5b6",
+          "@openzeppelin/contracts/utils/introspection/ERC165.sol": "61a2b12c96857aaa35f48aeda67a4281637a42494c0b3795be0ae976aa7b3793",
+          "@openzeppelin/contracts/utils/introspection/IERC165.sol": "9055c2994b37dea1a41b7b7926dcb510f05dbe2540b0aafc5fbee9558fffd0ca",
+          "contracts/Wrapper.sol": "4d8766bd7baa0a1bd2b021c0de27a04c59219d86fd0c907973e7873e5b069915",
+          "contracts/token/PartialCommonOwnership.sol": "5429da466a15811ce0196b99b710f247b3d6392c81cce2b84cab5ab83129c825",
+          "contracts/token/modules/Beneficiary.sol": "91e507656ebd6ec2d5ae5dfe2fe24ba0e30cea87b3deb14dd5e6140479e61500",
+          "contracts/token/modules/ERC721.sol": "7bcb9d453294af951005305c25003c0754643c1c53cb3f310436b31931192e1b",
+          "contracts/token/modules/Lease.sol": "269ec676c2a8bdd8148b0e2ce8743da676c220109583df569f95673bfaaac34f",
+          "contracts/token/modules/Remittance.sol": "3b9c9c0efea65e5256c7faad8061342b9764f58d5676550088b587d46d73bcc6",
+          "contracts/token/modules/Taxation.sol": "72aa02e63d76e28e6f04e29ea49e81a764f2211955e032a907fe0a7e524b0027",
+          "contracts/token/modules/Valuation.sol": "10b3450c7a2bc9c0b1f12f774c34abd70338480f908dc77d448d0de425adca02",
+          "contracts/token/modules/interfaces/IBeneficiary.sol": "b65dfa02ee1a1a6d89694323bc5b621f6c5504d8d1ab640a9ae03189fb3dceff",
+          "contracts/token/modules/interfaces/ILease.sol": "6373d8ce3d99fca346278de04dfedaaefc46ed7b4e4812b1b8737a03abbccfa1",
+          "contracts/token/modules/interfaces/IRemittance.sol": "aec91c493f5b6482d97a55031a559ba8084e93c6112e49742dadc1c91af987eb",
+          "contracts/token/modules/interfaces/ITaxation.sol": "78b7663a40929bfd7afc0c4315abf6365287fd17ca9986479c963aedfb28de42",
+          "contracts/token/modules/interfaces/IValuation.sol": "d7fd7c28b9a78a1e194b20f7e1a1c8c0b13b47df237f1c7defa95e45f6201e06"
+        }
+      },
+      "sourceCount": 24,
+      "sourceNamesSha256": "c2b32297ccca42832b645845a77dc45bc2991141c7d7e2bc1244125c595dc805"
+    },
+    "dependencyMigration": {
+      "installed": {
+        "@nomicfoundation/hardhat-ethers": {
+          "packageJsonSha256": "226daa6f645e7d245ed33574e0467b1bbffc9e68fb6d8d5119dcd7ab00080e28",
+          "version": "3.1.3"
+        },
+        "ethers": {
+          "packageJsonSha256": "d644d7df228197962e4ca19824b06e8d50dce0b5ee2aced63dcfc2a11ec7b90f",
+          "version": "6.17.0"
+        },
+        "hardhat": {
+          "packageJsonSha256": "57797013c50911ae0148e38851f6c232b1d6d9dc27c3ebbd3d82beffbb1b87a2",
+          "version": "2.28.6"
+        }
+      },
+      "lockfileSha256": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+      "openZeppelin": {
+        "equalToStage11": true,
+        "installedPackageJsonSha256": "3c1a597cb911ffc2988c038d83ee93e1f8bf0ad17769d6bb0368d08bc350d773",
+        "registryIntegrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
+        "version": "5.6.1"
+      },
+      "packageJsonSha256": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+      "registryIntegrity": {
+        "ethers": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+        "hardhatEthers": "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA=="
+      },
+      "transition": {
+        "dormantEthers5Tooling": {
+          "@nomiclabs/hardhat-ethers": "2.0.5",
+          "@nomiclabs/hardhat-waffle": "2.0.3",
+          "@typechain/ethers-v5": "10.0.0",
+          "@typechain/hardhat": "6.0.0",
+          "ethereum-waffle": "3.4.4",
+          "typechain": "8.0.0"
+        },
+        "ethers": {
+          "candidate": "6.17.0",
+          "stage11": "5.6.2"
+        },
+        "hardhat": {
+          "candidate": "2.28.6",
+          "stage11": "2.28.6"
+        },
+        "hardhatEthers": {
+          "candidate": {
+            "name": "@nomicfoundation/hardhat-ethers",
+            "version": "3.1.3"
+          },
+          "stage11": {
+            "name": "@nomiclabs/hardhat-ethers",
+            "version": "2.0.5"
+          }
+        },
+        "packageDifferences": [
+          {
+            "candidateValue": "3.1.3",
+            "path": "$.packageJson.devDependencies.@nomicfoundation/hardhat-ethers"
+          },
+          {
+            "baselineValue": "5.6.2",
+            "candidateValue": "6.17.0",
+            "path": "$.packageJson.devDependencies.ethers"
+          },
+          {
+            "baselineValue": "hardhat typechain && hardhat --network hardhat test tests/Interoperability.smoke.ts",
+            "candidateValue": "hardhat --network hardhat test tests/Interoperability.smoke.ts",
+            "path": "$.packageJson.scripts.test:hardhat:smoke"
+          },
+          {
+            "baselineValue": "hardhat typechain",
+            "path": "$.packageJson.scripts.typechain"
+          }
+        ],
+        "peerDebtDisposition": "retained but runtime-deactivated without suppression; remove together in Stage 12b",
+        "retainedLegacyHelpers": {
+          "@ethersproject/abi": "5.6.0",
+          "@ethersproject/contracts": "5.6.0",
+          "@ethersproject/providers": "5.6.2"
+        },
+        "unchangedActiveLegacyPlugin": {
+          "@nomiclabs/hardhat-web3": "2.0.0"
+        }
+      }
+    },
+    "productionSources": {
+      "contracts/Wrapper.sol": {
+        "equal": true,
+        "sha256": "4d8766bd7baa0a1bd2b021c0de27a04c59219d86fd0c907973e7873e5b069915"
+      },
+      "contracts/token/PartialCommonOwnership.sol": {
+        "equal": true,
+        "sha256": "5429da466a15811ce0196b99b710f247b3d6392c81cce2b84cab5ab83129c825"
+      },
+      "contracts/token/modules/Beneficiary.sol": {
+        "equal": true,
+        "sha256": "91e507656ebd6ec2d5ae5dfe2fe24ba0e30cea87b3deb14dd5e6140479e61500"
+      },
+      "contracts/token/modules/ERC721.sol": {
+        "equal": true,
+        "sha256": "7bcb9d453294af951005305c25003c0754643c1c53cb3f310436b31931192e1b"
+      },
+      "contracts/token/modules/Lease.sol": {
+        "equal": true,
+        "sha256": "269ec676c2a8bdd8148b0e2ce8743da676c220109583df569f95673bfaaac34f"
+      },
+      "contracts/token/modules/Remittance.sol": {
+        "equal": true,
+        "sha256": "3b9c9c0efea65e5256c7faad8061342b9764f58d5676550088b587d46d73bcc6"
+      },
+      "contracts/token/modules/Taxation.sol": {
+        "equal": true,
+        "sha256": "72aa02e63d76e28e6f04e29ea49e81a764f2211955e032a907fe0a7e524b0027"
+      },
+      "contracts/token/modules/Valuation.sol": {
+        "equal": true,
+        "sha256": "10b3450c7a2bc9c0b1f12f774c34abd70338480f908dc77d448d0de425adca02"
+      },
+      "contracts/token/modules/interfaces/IBeneficiary.sol": {
+        "equal": true,
+        "sha256": "b65dfa02ee1a1a6d89694323bc5b621f6c5504d8d1ab640a9ae03189fb3dceff"
+      },
+      "contracts/token/modules/interfaces/ILease.sol": {
+        "equal": true,
+        "sha256": "6373d8ce3d99fca346278de04dfedaaefc46ed7b4e4812b1b8737a03abbccfa1"
+      },
+      "contracts/token/modules/interfaces/IRemittance.sol": {
+        "equal": true,
+        "sha256": "aec91c493f5b6482d97a55031a559ba8084e93c6112e49742dadc1c91af987eb"
+      },
+      "contracts/token/modules/interfaces/ITaxation.sol": {
+        "equal": true,
+        "sha256": "78b7663a40929bfd7afc0c4315abf6365287fd17ca9986479c963aedfb28de42"
+      },
+      "contracts/token/modules/interfaces/IValuation.sol": {
+        "equal": true,
+        "sha256": "d7fd7c28b9a78a1e194b20f7e1a1c8c0b13b47df237f1c7defa95e45f6201e06"
+      }
+    },
+    "runtimeBridge": {
+      "active": {
+        "ethers": "6.17.0",
+        "hardhat": "2.28.6",
+        "plugin": {
+          "name": "@nomicfoundation/hardhat-ethers",
+          "version": "3.1.3"
+        }
+      },
+      "deactivatedHardhatRuntimeHooks": [
+        "@nomiclabs/hardhat-ethers",
+        "@nomiclabs/hardhat-waffle",
+        "@typechain/hardhat"
+      ],
+      "dormantEthers5Tooling": {
+        "@nomiclabs/hardhat-ethers": "2.0.5",
+        "@nomiclabs/hardhat-waffle": "2.0.3",
+        "@typechain/ethers-v5": "10.0.0",
+        "@typechain/hardhat": "6.0.0",
+        "ethereum-waffle": "3.4.4",
+        "typechain": "8.0.0"
+      },
+      "files": {
+        "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+        "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+        "tests/Interoperability.smoke.ts": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350",
+        "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+      },
+      "retainedLegacyHelpers": {
+        "@ethersproject/abi": "5.6.0",
+        "@ethersproject/contracts": "5.6.0",
+        "@ethersproject/providers": "5.6.2"
+      },
+      "smokeRunner": "hardhat --network hardhat test tests/Interoperability.smoke.ts",
+      "typeScriptInclude": [
+        "./scripts",
+        "./tests/Interoperability.smoke.ts"
+      ],
+      "unchangedActiveLegacyPlugin": {
+        "@nomiclabs/hardhat-web3": "2.0.0"
+      }
+    },
+    "tests": {
+      "forge": {
+        "count": 140,
+        "mappedBehaviorCount": 104,
+        "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173",
+        "safetyCount": 36
+      },
+      "hardhat": {
+        "count": 3,
+        "names": [
+          "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+          "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+          "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+        ],
+        "namesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f"
+      },
+      "toolingInventory": {
+        "activeHardhat": {
+          "count": 3,
+          "names": [
+            "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+            "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+            "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+          ],
+          "sourcePath": "tests/Interoperability.smoke.ts",
+          "sourceSha256": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350"
+        },
+        "candidate": "stage-12a-ethers-6",
+        "forge": {
+          "count": 140,
+          "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173"
+        },
+        "inheritedStage11": {
+          "hardhatNamesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f",
+          "inventoryPath": "compatibility/stage-11-hardhat-smoke-inventory.json",
+          "inventorySha256": "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4",
+          "smokeSourceSha256": "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a"
+        },
+        "parity": {
+          "files": {
+            "compatibility/parity-map.json": "72f66deac5693d553a681afa755856cc87f2d52d4b109938862ba731da9443b4",
+            "compatibility/parity/cohort-0-existing-forge.json": "3384ae9039fad21bb7800d61f181bd4ca6b68a8e1e8525815c3cc8ecd434df69",
+            "compatibility/parity/cohort-1-pco-read-tax.json": "632c07354ab5f4e0d71290e2631da59bacad8cc3c0bc1d22cc129674098891fc",
+            "compatibility/parity/cohort-2-pco-mutations.json": "47b93d5ecd3734b09533c8af0c514274ad4ff3c90185a6724364060bf5eef5c1",
+            "compatibility/parity/cohort-3-wrapper.json": "4932bd7dd4da1cf55b2723e98cbe865737c9e735528ad70f05f8de85c2baecca",
+            "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a"
+          },
+          "mappedBehaviorCount": 104,
+          "safetyCount": 36
+        },
+        "path": "compatibility/stage-12a-ethers6-inventory.json",
+        "schemaVersion": 1,
+        "sha256": "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+        "stage11Checkpoint": "c84870955d77e82e91ed70591f010233675a6880",
+        "tooling": {
+          "ethers": "6.17.0",
+          "files": {
+            "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+            "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+            "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+            "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+            "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+          },
+          "hardhat": "2.28.6",
+          "hardhatEthers": "3.1.3"
+        }
+      },
+      "total": 143
+    },
+    "toolingInventory": {
+      "activeHardhat": {
+        "count": 3,
+        "names": [
+          "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+          "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+          "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+        ],
+        "sourcePath": "tests/Interoperability.smoke.ts",
+        "sourceSha256": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350"
+      },
+      "candidate": "stage-12a-ethers-6",
+      "forge": {
+        "count": 140,
+        "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173"
+      },
+      "inheritedStage11": {
+        "hardhatNamesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f",
+        "inventoryPath": "compatibility/stage-11-hardhat-smoke-inventory.json",
+        "inventorySha256": "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4",
+        "smokeSourceSha256": "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a"
+      },
+      "parity": {
+        "files": {
+          "compatibility/parity-map.json": "72f66deac5693d553a681afa755856cc87f2d52d4b109938862ba731da9443b4",
+          "compatibility/parity/cohort-0-existing-forge.json": "3384ae9039fad21bb7800d61f181bd4ca6b68a8e1e8525815c3cc8ecd434df69",
+          "compatibility/parity/cohort-1-pco-read-tax.json": "632c07354ab5f4e0d71290e2631da59bacad8cc3c0bc1d22cc129674098891fc",
+          "compatibility/parity/cohort-2-pco-mutations.json": "47b93d5ecd3734b09533c8af0c514274ad4ff3c90185a6724364060bf5eef5c1",
+          "compatibility/parity/cohort-3-wrapper.json": "4932bd7dd4da1cf55b2723e98cbe865737c9e735528ad70f05f8de85c2baecca",
+          "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a"
+        },
+        "mappedBehaviorCount": 104,
+        "safetyCount": 36
+      },
+      "path": "compatibility/stage-12a-ethers6-inventory.json",
+      "schemaVersion": 1,
+      "sha256": "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+      "stage11Checkpoint": "c84870955d77e82e91ed70591f010233675a6880",
+      "tooling": {
+        "ethers": "6.17.0",
+        "files": {
+          "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+          "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+          "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+          "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+          "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+        },
+        "hardhat": "2.28.6",
+        "hardhatEthers": "3.1.3"
+      }
+    }
+  }
+}

--- a/compatibility/reviewed-differences.json
+++ b/compatibility/reviewed-differences.json
@@ -1,83 +1,247 @@
 {
-  "allowedDifferences": [
-    {
-      "baselineValue": 89,
-      "candidateValue": 3,
-      "path": "$.tests.hardhat.count",
-      "reason": "Stage 11 retires only the two digest-bound legacy TypeScript behavior sources after exact 104/104 Forge parity and keeps exactly three digest-bound Hardhat interoperability smokes. The historical 89-name oracle and parity map remain immutable provenance, and all 140 Forge identifiers remain active and exact."
-    },
-    {
-      "baselineValue": 89,
-      "candidateValue": 3,
-      "path": "$.tests.hardhat.names.length",
-      "reason": "Stage 11 retires only the two digest-bound legacy TypeScript behavior sources after exact 104/104 Forge parity and keeps exactly three digest-bound Hardhat interoperability smokes. The historical 89-name oracle and parity map remain immutable provenance, and all 140 Forge identifiers remain active and exact."
-    },
-    {
-      "baselineValue": "PartialCommonOwnership.sol #collectTax() succeeds collects after 10m",
-      "candidateValue": "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
-      "path": "$.tests.hardhat.names[0]",
-      "reason": "Stage 11 retires only the two digest-bound legacy TypeScript behavior sources after exact 104/104 Forge parity and keeps exactly three digest-bound Hardhat interoperability smokes. The historical 89-name oracle and parity map remain immutable provenance, and all 140 Forge identifiers remain active and exact."
-    },
-    {
-      "baselineValue": "PartialCommonOwnership.sol #collectTax() succeeds collects after 10m and subsequently after 10m",
-      "candidateValue": "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
-      "path": "$.tests.hardhat.names[1]",
-      "reason": "Stage 11 retires only the two digest-bound legacy TypeScript behavior sources after exact 104/104 Forge parity and keeps exactly three digest-bound Hardhat interoperability smokes. The historical 89-name oracle and parity map remain immutable provenance, and all 140 Forge identifiers remain active and exact."
-    },
-    {
-      "baselineValue": "PartialCommonOwnership.sol #collectTax() succeeds no tax collected if token is owned by its beneficiary",
-      "candidateValue": "Hardhat interoperability smokes deploys and reads deterministic PCO configuration",
-      "path": "$.tests.hardhat.names[2]",
-      "reason": "Stage 11 retires only the two digest-bound legacy TypeScript behavior sources after exact 104/104 Forge parity and keeps exactly three digest-bound Hardhat interoperability smokes. The historical 89-name oracle and parity map remain immutable provenance, and all 140 Forge identifiers remain active and exact."
-    },
-    {
-      "baselineValue": 229,
-      "candidateValue": 143,
-      "path": "$.tests.total",
-      "reason": "Stage 11 retires only the two digest-bound legacy TypeScript behavior sources after exact 104/104 Forge parity and keeps exactly three digest-bound Hardhat interoperability smokes. The historical 89-name oracle and parity map remain immutable provenance, and all 140 Forge identifiers remain active and exact."
-    }
-  ],
+  "allowedDifferences": [],
   "baselineSha256": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
-  "candidate": "stage-11-foundry-first-cutover",
+  "candidate": "stage-12a-ethers-6",
+  "migrationEvidence": {
+    "boundFiles": {
+      "compatibility/README.md": "cccac2d4fb89015cdbe20197a9c08d78ecc90c11384d485690b471e42e390df8",
+      "compatibility/stage-12a-ethers6-inventory.json": "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+      "docs/development.md": "ab764805a0d8d4679dca1f6b2043ba3f21ea2b5420d567558719a3d5c2109727",
+      "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+      "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+      "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+      "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+      "scripts/check-parity.js": "540ef384dda01295a357a048290bb89004d3aa64a5e7455b73ff3c08fe37f53a",
+      "tests/Interoperability.smoke.ts": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350",
+      "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+    },
+    "checkpoint": {
+      "commit": "c84870955d77e82e91ed70591f010233675a6880",
+      "evidence": {
+        "path": "compatibility/evidence/stage-11-foundry-first-cutover.json",
+        "sha256": "0077542e6ac4c5f1af3813ff8e84dcc4d46182f1a8c0b28e290acfae733da412"
+      },
+      "review": {
+        "path": "compatibility/reviewed-differences.json",
+        "sha256": "4dfa67856a3d5d04a1057df5064926a07fd1dcde314b05bbdd1927a3080b7731"
+      }
+    },
+    "dependencyMigration": {
+      "installed": {
+        "@nomicfoundation/hardhat-ethers": {
+          "packageJsonSha256": "226daa6f645e7d245ed33574e0467b1bbffc9e68fb6d8d5119dcd7ab00080e28",
+          "version": "3.1.3"
+        },
+        "ethers": {
+          "packageJsonSha256": "d644d7df228197962e4ca19824b06e8d50dce0b5ee2aced63dcfc2a11ec7b90f",
+          "version": "6.17.0"
+        },
+        "hardhat": {
+          "packageJsonSha256": "57797013c50911ae0148e38851f6c232b1d6d9dc27c3ebbd3d82beffbb1b87a2",
+          "version": "2.28.6"
+        }
+      },
+      "lockfileSha256": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+      "openZeppelin": {
+        "equalToStage11": true,
+        "installedPackageJsonSha256": "3c1a597cb911ffc2988c038d83ee93e1f8bf0ad17769d6bb0368d08bc350d773",
+        "registryIntegrity": "sha512-Ly6SlsVJ3mj+b18W3R8gNufB7dTICT105fJhodGAGgyC2oqnBAhqSiNDJ8V8DLY05cCz81GLI0CU5vNYA1EC/w==",
+        "version": "5.6.1"
+      },
+      "packageJsonSha256": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+      "registryIntegrity": {
+        "ethers": "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==",
+        "hardhatEthers": "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA=="
+      },
+      "transition": {
+        "dormantEthers5Tooling": {
+          "@nomiclabs/hardhat-ethers": "2.0.5",
+          "@nomiclabs/hardhat-waffle": "2.0.3",
+          "@typechain/ethers-v5": "10.0.0",
+          "@typechain/hardhat": "6.0.0",
+          "ethereum-waffle": "3.4.4",
+          "typechain": "8.0.0"
+        },
+        "ethers": {
+          "candidate": "6.17.0",
+          "stage11": "5.6.2"
+        },
+        "hardhat": {
+          "candidate": "2.28.6",
+          "stage11": "2.28.6"
+        },
+        "hardhatEthers": {
+          "candidate": {
+            "name": "@nomicfoundation/hardhat-ethers",
+            "version": "3.1.3"
+          },
+          "stage11": {
+            "name": "@nomiclabs/hardhat-ethers",
+            "version": "2.0.5"
+          }
+        },
+        "packageDifferences": [
+          {
+            "candidateValue": "3.1.3",
+            "path": "$.packageJson.devDependencies.@nomicfoundation/hardhat-ethers"
+          },
+          {
+            "baselineValue": "5.6.2",
+            "candidateValue": "6.17.0",
+            "path": "$.packageJson.devDependencies.ethers"
+          },
+          {
+            "baselineValue": "hardhat typechain && hardhat --network hardhat test tests/Interoperability.smoke.ts",
+            "candidateValue": "hardhat --network hardhat test tests/Interoperability.smoke.ts",
+            "path": "$.packageJson.scripts.test:hardhat:smoke"
+          },
+          {
+            "baselineValue": "hardhat typechain",
+            "path": "$.packageJson.scripts.typechain"
+          }
+        ],
+        "peerDebtDisposition": "retained but runtime-deactivated without suppression; remove together in Stage 12b",
+        "retainedLegacyHelpers": {
+          "@ethersproject/abi": "5.6.0",
+          "@ethersproject/contracts": "5.6.0",
+          "@ethersproject/providers": "5.6.2"
+        },
+        "unchangedActiveLegacyPlugin": {
+          "@nomiclabs/hardhat-web3": "2.0.0"
+        }
+      }
+    },
+    "retainedTests": {
+      "forge": {
+        "count": 140,
+        "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173"
+      },
+      "hardhat": {
+        "count": 3,
+        "names": [
+          "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+          "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+          "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+        ]
+      }
+    },
+    "runtimeBridge": {
+      "active": {
+        "ethers": "6.17.0",
+        "hardhat": "2.28.6",
+        "plugin": {
+          "name": "@nomicfoundation/hardhat-ethers",
+          "version": "3.1.3"
+        }
+      },
+      "deactivatedHardhatRuntimeHooks": [
+        "@nomiclabs/hardhat-ethers",
+        "@nomiclabs/hardhat-waffle",
+        "@typechain/hardhat"
+      ],
+      "dormantEthers5Tooling": {
+        "@nomiclabs/hardhat-ethers": "2.0.5",
+        "@nomiclabs/hardhat-waffle": "2.0.3",
+        "@typechain/ethers-v5": "10.0.0",
+        "@typechain/hardhat": "6.0.0",
+        "ethereum-waffle": "3.4.4",
+        "typechain": "8.0.0"
+      },
+      "files": {
+        "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+        "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+        "tests/Interoperability.smoke.ts": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350",
+        "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+      },
+      "retainedLegacyHelpers": {
+        "@ethersproject/abi": "5.6.0",
+        "@ethersproject/contracts": "5.6.0",
+        "@ethersproject/providers": "5.6.2"
+      },
+      "smokeRunner": "hardhat --network hardhat test tests/Interoperability.smoke.ts",
+      "typeScriptInclude": [
+        "./scripts",
+        "./tests/Interoperability.smoke.ts"
+      ],
+      "unchangedActiveLegacyPlugin": {
+        "@nomiclabs/hardhat-web3": "2.0.0"
+      }
+    },
+    "toolingInventory": {
+      "activeHardhat": {
+        "count": 3,
+        "names": [
+          "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+          "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+          "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+        ],
+        "sourcePath": "tests/Interoperability.smoke.ts",
+        "sourceSha256": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350"
+      },
+      "candidate": "stage-12a-ethers-6",
+      "forge": {
+        "count": 140,
+        "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173"
+      },
+      "inheritedStage11": {
+        "hardhatNamesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f",
+        "inventoryPath": "compatibility/stage-11-hardhat-smoke-inventory.json",
+        "inventorySha256": "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4",
+        "smokeSourceSha256": "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a"
+      },
+      "parity": {
+        "files": {
+          "compatibility/parity-map.json": "72f66deac5693d553a681afa755856cc87f2d52d4b109938862ba731da9443b4",
+          "compatibility/parity/cohort-0-existing-forge.json": "3384ae9039fad21bb7800d61f181bd4ca6b68a8e1e8525815c3cc8ecd434df69",
+          "compatibility/parity/cohort-1-pco-read-tax.json": "632c07354ab5f4e0d71290e2631da59bacad8cc3c0bc1d22cc129674098891fc",
+          "compatibility/parity/cohort-2-pco-mutations.json": "47b93d5ecd3734b09533c8af0c514274ad4ff3c90185a6724364060bf5eef5c1",
+          "compatibility/parity/cohort-3-wrapper.json": "4932bd7dd4da1cf55b2723e98cbe865737c9e735528ad70f05f8de85c2baecca",
+          "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a"
+        },
+        "mappedBehaviorCount": 104,
+        "safetyCount": 36
+      },
+      "path": "compatibility/stage-12a-ethers6-inventory.json",
+      "schemaVersion": 1,
+      "sha256": "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+      "stage11Checkpoint": "c84870955d77e82e91ed70591f010233675a6880",
+      "tooling": {
+        "ethers": "6.17.0",
+        "files": {
+          "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+          "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+          "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+          "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+          "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+        },
+        "hardhat": "2.28.6",
+        "hardhatEthers": "3.1.3"
+      }
+    }
+  },
   "opcodeEvidence": {
     "contracts": [
       "contracts/Wrapper.sol:Wrapper",
       "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership"
     ],
-    "mode": "stage-11-stage-10-production-equality",
-    "path": "compatibility/evidence/stage-11-foundry-first-cutover.json"
+    "mode": "stage-12a-stage-11-production-equality",
+    "path": "compatibility/evidence/stage-12a-ethers-6.json"
   },
-  "policy": "stage-11-foundry-first-cutover",
+  "policy": "stage-12a-ethers-6-stage-11-equality",
   "safetyEvidence": {
     "path": "compatibility/evidence/stage-07-safety-artifacts.json",
     "sha256": "0065814caec6e3044951f80c891c9948454e90138d016513ed07d0fcfb7c67d8"
   },
   "schemaVersion": 1,
-  "smokeEvidence": {
-    "deletedLegacyFiles": {
-      "tests/PartialCommonOwnership/index.ts": "729d6297377a6be11ebb122a8413a27985da990c108e70522512c70d98e7c134",
-      "tests/Wrapper.ts": "35377ba00ea68479a517bcfe3873552a13e07563a040091c3b436345111b6a1c"
-    },
-    "historicalNamesSha256": "861cda9b6fe70b931fd4c049c2e75585fd53a2ba502a3f89a70980a520f9a3ce",
-    "names": [
-      "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
-      "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
-      "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
-    ],
-    "path": "compatibility/stage-11-hardhat-smoke-inventory.json",
-    "sha256": "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4",
-    "sourcePath": "tests/Interoperability.smoke.ts",
-    "sourceSha256": "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a"
-  },
-  "stage10Checkpoint": {
-    "commit": "14720718787046af58be50c110be40c18f5b1364",
+  "stage11Checkpoint": {
+    "commit": "c84870955d77e82e91ed70591f010233675a6880",
     "evidence": {
-      "path": "compatibility/evidence/stage-10-openzeppelin-5-6-1.json",
-      "sha256": "41997589806cfb2549751713ad754816bab1259a172bebdea6ec957494437d60"
+      "path": "compatibility/evidence/stage-11-foundry-first-cutover.json",
+      "sha256": "0077542e6ac4c5f1af3813ff8e84dcc4d46182f1a8c0b28e290acfae733da412"
     },
     "review": {
       "path": "compatibility/reviewed-differences.json",
-      "sha256": "9940b3d2e4408ea7221bf05b98d7d16a97078aa0f2334c4dfec9af83b5533cef"
+      "sha256": "4dfa67856a3d5d04a1057df5064926a07fd1dcde314b05bbdd1927a3080b7731"
     }
   }
 }

--- a/compatibility/stage-12a-ethers6-inventory.json
+++ b/compatibility/stage-12a-ethers6-inventory.json
@@ -1,0 +1,49 @@
+{
+  "schemaVersion": 1,
+  "candidate": "stage-12a-ethers-6",
+  "stage11Checkpoint": "c84870955d77e82e91ed70591f010233675a6880",
+  "inheritedStage11": {
+    "inventoryPath": "compatibility/stage-11-hardhat-smoke-inventory.json",
+    "inventorySha256": "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4",
+    "hardhatNamesSha256": "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f",
+    "smokeSourceSha256": "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a"
+  },
+  "activeHardhat": {
+    "count": 3,
+    "names": [
+      "Hardhat interoperability smokes acquires, collects tax, and exits with ordered events and conserved balances",
+      "Hardhat interoperability smokes approves, wraps, takes over, and unwraps with custody and metadata cleanup",
+      "Hardhat interoperability smokes deploys and reads deterministic PCO configuration"
+    ],
+    "sourcePath": "tests/Interoperability.smoke.ts",
+    "sourceSha256": "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350"
+  },
+  "forge": {
+    "count": 140,
+    "namesSha256": "09b141a8c69c4522288cfdbf67373661052764ab019c865ea850dc5eb645f173"
+  },
+  "tooling": {
+    "hardhat": "2.28.6",
+    "ethers": "6.17.0",
+    "hardhatEthers": "3.1.3",
+    "files": {
+      "hardhat.config.d.ts": "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+      "hardhat.config.ts": "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+      "package.json": "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+      "pnpm-lock.yaml": "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+      "tsconfig.json": "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488"
+    }
+  },
+  "parity": {
+    "mappedBehaviorCount": 104,
+    "safetyCount": 36,
+    "files": {
+      "compatibility/parity-map.json": "72f66deac5693d553a681afa755856cc87f2d52d4b109938862ba731da9443b4",
+      "compatibility/parity/cohort-0-existing-forge.json": "3384ae9039fad21bb7800d61f181bd4ca6b68a8e1e8525815c3cc8ecd434df69",
+      "compatibility/parity/cohort-1-pco-read-tax.json": "632c07354ab5f4e0d71290e2631da59bacad8cc3c0bc1d22cc129674098891fc",
+      "compatibility/parity/cohort-2-pco-mutations.json": "47b93d5ecd3734b09533c8af0c514274ad4ff3c90185a6724364060bf5eef5c1",
+      "compatibility/parity/cohort-3-wrapper.json": "4932bd7dd4da1cf55b2723e98cbe865737c9e735528ad70f05f8de85c2baecca",
+      "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a"
+    }
+  }
+}

--- a/docs/development.md
+++ b/docs/development.md
@@ -46,6 +46,13 @@ configuration; acquire, collect tax, and exit while decoding events; and
 approve, wrap, takeover, and unwrap while verifying custody. It is an
 interoperability signal, not a second behavior oracle.
 
+The smokes use exactly ethers 6.17.0 through
+`@nomicfoundation/hardhat-ethers` 3.1.3 while Hardhat remains pinned to 2.28.6.
+The installed ethers 5 Waffle, NomicLabs ethers, and TypeChain packages are
+dormant in this bridge stage: none is loaded or invoked. They are retained only
+so their removal stays isolated in the subsequent Hardhat 3 tooling PR. The
+unrelated Web3 plugin remains active until that same cleanup.
+
 The Forge command enforces the checked-in 104-entry parity map. The 89 legacy
 Hardhat behavior scenarios and 15 original Forge scenarios each map to one
 unique, successful Forge regression. The 89 TypeScript behavior tests were

--- a/hardhat.config.d.ts
+++ b/hardhat.config.d.ts
@@ -1,3 +1,2 @@
 /** Type declarations for Hardhat plugins that are implicitly added to the `hre` namespace. */
-/// <reference path="./node_modules/@nomiclabs/hardhat-ethers/internal/index.d.ts" />
-/// <reference path="./node_modules/@nomiclabs/hardhat-waffle/dist/src/index.d.ts" />
+/// <reference path="./node_modules/@nomicfoundation/hardhat-ethers/internal/index.d.ts" />

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,6 +1,5 @@
 // Import Hardhat extensions
-import "@nomiclabs/hardhat-ethers";
-import "@nomiclabs/hardhat-waffle";
+import "@nomicfoundation/hardhat-ethers";
 import "@nomiclabs/hardhat-web3";
 import "hardhat-gas-reporter";
 import "solidity-coverage";
@@ -14,12 +13,6 @@ import dotenv from "dotenv";
 dotenv.config({
   path: path.resolve(process.cwd(), ".env"),
 });
-
-// Type compilation can be turned off.  This is useful when compiling for
-// coverage determination.
-if (process.env.TYPE_COMPILATION !== "false") {
-  require("@typechain/hardhat");
-}
 
 // Ignore Forge-only test sources during Hardhat compilation; Forge resolves its
 // pinned test library from the retained git submodule.
@@ -81,9 +74,5 @@ export default {
     enabled: process.env.REPORT_GAS === "true",
     currency: "USD",
     coinmarketcap: process.env.COINMARKETCAP_API_KEY,
-  },
-  typechain: {
-    outDir: "types",
-    target: "ethers-v5",
   },
 };

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "compiler-warnings:forge": "node scripts/check-compiler-warnings.js forge",
     "compiler-warnings:check": "pnpm run compiler-warnings:hardhat && pnpm run compiler-warnings:forge",
     "test:hardhat": "pnpm run test:hardhat:smoke",
-    "test:hardhat:smoke": "hardhat typechain && hardhat --network hardhat test tests/Interoperability.smoke.ts",
+    "test:hardhat:smoke": "hardhat --network hardhat test tests/Interoperability.smoke.ts",
     "test:forge": "node scripts/check-parity.js",
     "test:safety": "cross-env FOUNDRY_PROFILE=ci node scripts/check-parity.js",
     "test:safety:scheduled": "cross-env FOUNDRY_PROFILE=scheduled node scripts/check-parity.js",
@@ -57,13 +57,13 @@
     "gas:check": "node scripts/check-gas.js",
     "safety-baselines:check": "node scripts/check-safety-baselines.js",
     "size:check": "node scripts/check-contract-sizes.js",
-    "slither": "node scripts/run-slither.js",
-    "typechain": "hardhat typechain"
+    "slither": "node scripts/run-slither.js"
   },
   "devDependencies": {
     "@ethersproject/abi": "5.6.0",
     "@ethersproject/contracts": "5.6.0",
     "@ethersproject/providers": "5.6.2",
+    "@nomicfoundation/hardhat-ethers": "3.1.3",
     "@nomiclabs/hardhat-ethers": "2.0.5",
     "@nomiclabs/hardhat-waffle": "2.0.3",
     "@nomiclabs/hardhat-web3": "2.0.0",
@@ -78,7 +78,7 @@
     "cross-env": "7.0.3",
     "dotenv": "10.0.0",
     "ethereum-waffle": "3.4.4",
-    "ethers": "5.6.2",
+    "ethers": "6.17.0",
     "hardhat": "2.28.6",
     "hardhat-gas-reporter": "1.0.8",
     "js-yaml": "4.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,12 +24,15 @@ importers:
       '@ethersproject/providers':
         specifier: 5.6.2
         version: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+      '@nomicfoundation/hardhat-ethers':
+        specifier: 3.1.3
+        version: 3.1.3(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
       '@nomiclabs/hardhat-ethers':
         specifier: 2.0.5
-        version: 2.0.5(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
+        version: 2.0.5(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
       '@nomiclabs/hardhat-waffle':
         specifier: 2.0.3
-        version: 2.0.3(@nomiclabs/hardhat-ethers@2.0.5(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)))(ethereum-waffle@3.4.4(bufferutil@4.0.6)(encoding@0.1.13)(supports-color@8.1.1)(typescript@4.6.3)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
+        version: 2.0.3(@nomiclabs/hardhat-ethers@2.0.5(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)))(ethereum-waffle@3.4.4(bufferutil@4.0.6)(encoding@0.1.13)(supports-color@8.1.1)(typescript@4.6.3)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
       '@nomiclabs/hardhat-web3':
         specifier: 2.0.0
         version: 2.0.0(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(web3@1.7.1(bufferutil@4.0.6)(utf-8-validate@5.0.9))
@@ -38,10 +41,10 @@ importers:
         version: 0.5.15(bn.js@4.12.0)(bufferutil@4.0.6)(supports-color@8.1.1)(utf-8-validate@5.0.9)
       '@typechain/ethers-v5':
         specifier: 10.0.0
-        version: 10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3)
+        version: 10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3)
       '@typechain/hardhat':
         specifier: 6.0.0
-        version: 6.0.0(@ethersproject/abi@5.6.0)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(@typechain/ethers-v5@10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))
+        version: 6.0.0(@ethersproject/abi@5.6.0)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(@typechain/ethers-v5@10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))
       '@types/chai':
         specifier: 4.3.0
         version: 4.3.0
@@ -67,8 +70,8 @@ importers:
         specifier: 3.4.4
         version: 3.4.4(bufferutil@4.0.6)(encoding@0.1.13)(supports-color@8.1.1)(typescript@4.6.3)(utf-8-validate@5.0.9)
       ethers:
-        specifier: 5.6.2
-        version: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+        specifier: 6.17.0
+        version: 6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
       hardhat:
         specifier: 2.28.6
         version: 2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)
@@ -107,6 +110,9 @@ importers:
         version: 1.7.1(bufferutil@4.0.6)(utf-8-validate@5.0.9)
 
 packages:
+
+  '@adraffy/ens-normalize@1.11.1':
+    resolution: {integrity: sha512-nhCBV3quEgesuf7c7KYfperqSS14T8bYuvJ8PcLJp6znkZpFc0AuW4qBtr8eKVyPPe/8RSr7sglCWPU5eaxwKQ==}
 
   '@babel/code-frame@7.16.7':
     resolution: {integrity: sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==}
@@ -281,6 +287,9 @@ packages:
     resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
     engines: {node: '>=14'}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.4.2':
     resolution: {integrity: sha512-TavHr8qycMChk8UwMld0ZDRvatedkzWfH8IiaeGCfymOP5i0hSCozz9vHOL0nkwk7HRMlFnAiKpS2jrUmSybcw==}
 
@@ -290,6 +299,10 @@ packages:
 
   '@noble/hashes@1.0.0':
     resolution: {integrity: sha512-DZVbtY62kc3kkBtMHqwCOfXrT/hnoORy5BJ4+HU1IR59X0KWAOqsfzQPcUl/lQLlG7qXbe/fZ3r/emxtAl+sqg==}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -345,6 +358,12 @@ packages:
   '@nomicfoundation/edr@0.12.0-next.23':
     resolution: {integrity: sha512-F2/6HZh8Q9RsgkOIkRrckldbhPjIZY7d4mT9LYuW68miwGQ5l7CkAgcz9fRRiurA0+YJhtsbx/EyrD9DmX9BOw==}
     engines: {node: '>= 20'}
+
+  '@nomicfoundation/hardhat-ethers@3.1.3':
+    resolution: {integrity: sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==}
+    peerDependencies:
+      ethers: ^6.14.0
+      hardhat: ^2.28.0
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0':
     resolution: {integrity: sha512-vEF3yKuuzfMHsZecHQcnkUrqm8mnTWfJeEVFHpg+cO+le96xQA4lAJYdUan8pXZohQxv1fSReQsn4QGNuBNuCw==}
@@ -646,8 +665,8 @@ packages:
   '@types/node@16.11.26':
     resolution: {integrity: sha512-GZ7bu5A6+4DtG7q9GsoHXy3ALcgeIHP4NnL0Vv2wu0uUB/yQex26v0tf6/na1mm0+bS9Uw+0DFex7aaKr2qawQ==}
 
-  '@types/node@17.0.23':
-    resolution: {integrity: sha512-UxDxWn7dl97rKVeVS61vErvw086aCYhDLyvRQZ5Rk65rZKepaFdm53GeqXaKBuOhED4e9uWq34IC3TdSdJJ2Gw==}
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/node@8.10.66':
     resolution: {integrity: sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw==}
@@ -748,6 +767,9 @@ packages:
 
   aes-js@3.1.2:
     resolution: {integrity: sha512-e5pEa2kBnBOgR4Y/p20pskXI74UEz7de8ZGVo58asOtvSVG5YAbJeELPZxOmt+Bnz3rX753YKhfIn4X4l1PPRQ==}
+
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -2085,6 +2107,10 @@ packages:
   ethers@5.6.2:
     resolution: {integrity: sha512-EzGCbns24/Yluu7+ToWnMca3SXJ1Jk1BvWB7CCmVNxyOeM4LLvw2OLuIHhlkhQk1dtOcj9UMsdkxUh8RiG1dxQ==}
 
+  ethers@6.17.0:
+    resolution: {integrity: sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==}
+    engines: {node: '>=14.0.0'}
+
   ethjs-abi@0.2.1:
     resolution: {integrity: sha512-g2AULSDYI6nEJyJaEVEXtTimRY2aPC2fi7ddSy0W+LXvEVL8Fe1y76o43ecbgdUKwZD+xsmEgX1yJr1Ia3r1IA==}
     engines: {node: '>=6.5.0', npm: '>=3'}
@@ -3163,6 +3189,10 @@ packages:
 
   lodash.flatten@4.4.0:
     resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
+
+  lodash.isequal@4.5.0:
+    resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -4688,6 +4718,9 @@ packages:
   tslib@2.3.1:
     resolution: {integrity: sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tsort@0.0.1:
     resolution: {integrity: sha512-Tyrf5mxF8Ofs1tNoxA13lFeZ2Zrbd6cKbuH3V+MQ5sb6DtBj5FjrXVsRWT8YvNAQTqNoz66dz1WsbigI22aEnw==}
 
@@ -4787,6 +4820,9 @@ packages:
 
   underscore@1.9.1:
     resolution: {integrity: sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici@5.29.0:
     resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
@@ -5293,6 +5329,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xhr-request-promise@0.1.3:
     resolution: {integrity: sha512-YUBytBsuwgitWtdRzXDDkWAXzhdGB8bYm0sSzMPZT7Z2MBjMSTHFsyCT1yCRATY+XC69DUrQraRAEgcoCRaIPg==}
 
@@ -5379,6 +5427,8 @@ packages:
     engines: {node: '>=10'}
 
 snapshots:
+
+  '@adraffy/ens-normalize@1.11.1': {}
 
   '@babel/code-frame@7.16.7':
     dependencies:
@@ -5791,6 +5841,10 @@ snapshots:
 
   '@fastify/busboy@2.1.1': {}
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.4.2':
     dependencies:
       '@noble/hashes': 1.4.0
@@ -5800,6 +5854,8 @@ snapshots:
       '@noble/hashes': 1.7.2
 
   '@noble/hashes@1.0.0': {}
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -5842,6 +5898,15 @@ snapshots:
       '@nomicfoundation/edr-linux-x64-gnu': 0.12.0-next.23
       '@nomicfoundation/edr-linux-x64-musl': 0.12.0-next.23
       '@nomicfoundation/edr-win32-x64-msvc': 0.12.0-next.23
+
+  '@nomicfoundation/hardhat-ethers@3.1.3(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))':
+    dependencies:
+      debug: 4.3.4(supports-color@8.1.1)
+      ethers: 6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+      hardhat: 2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)
+      lodash.isequal: 4.5.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@nomicfoundation/solidity-analyzer-darwin-arm64@0.1.0':
     optional: true
@@ -5886,18 +5951,18 @@ snapshots:
       '@nomicfoundation/solidity-analyzer-win32-ia32-msvc': 0.1.0
       '@nomicfoundation/solidity-analyzer-win32-x64-msvc': 0.1.0
 
-  '@nomiclabs/hardhat-ethers@2.0.5(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))':
+  '@nomiclabs/hardhat-ethers@2.0.5(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))':
     dependencies:
-      ethers: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+      ethers: 6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
       hardhat: 2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)
 
-  '@nomiclabs/hardhat-waffle@2.0.3(@nomiclabs/hardhat-ethers@2.0.5(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)))(ethereum-waffle@3.4.4(bufferutil@4.0.6)(encoding@0.1.13)(supports-color@8.1.1)(typescript@4.6.3)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))':
+  '@nomiclabs/hardhat-waffle@2.0.3(@nomiclabs/hardhat-ethers@2.0.5(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)))(ethereum-waffle@3.4.4(bufferutil@4.0.6)(encoding@0.1.13)(supports-color@8.1.1)(typescript@4.6.3)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))':
     dependencies:
-      '@nomiclabs/hardhat-ethers': 2.0.5(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
+      '@nomiclabs/hardhat-ethers': 2.0.5(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))
       '@types/sinon-chai': 3.2.8
       '@types/web3': 1.0.19
       ethereum-waffle: 3.4.4(bufferutil@4.0.6)(encoding@0.1.13)(supports-color@8.1.1)(typescript@4.6.3)(utf-8-validate@5.0.9)
-      ethers: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+      ethers: 6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
       hardhat: 2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)
 
   '@nomiclabs/hardhat-web3@2.0.0(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(web3@1.7.1(bufferutil@4.0.6)(utf-8-validate@5.0.9))':
@@ -6159,12 +6224,12 @@ snapshots:
 
   '@tsconfig/node16@1.0.2': {}
 
-  '@typechain/ethers-v5@10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3)':
+  '@typechain/ethers-v5@10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3)':
     dependencies:
       '@ethersproject/abi': 5.6.0
       '@ethersproject/bytes': 5.6.1
       '@ethersproject/providers': 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
-      ethers: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+      ethers: 6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
       lodash: 4.17.21
       ts-essentials: 7.0.3(typescript@4.6.3)
       typechain: 8.0.0(supports-color@8.1.1)(typescript@4.6.3)
@@ -6175,12 +6240,12 @@ snapshots:
       ethers: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
       typechain: 3.0.0(supports-color@8.1.1)(typescript@4.6.3)
 
-  '@typechain/hardhat@6.0.0(@ethersproject/abi@5.6.0)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(@typechain/ethers-v5@10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))':
+  '@typechain/hardhat@6.0.0(@ethersproject/abi@5.6.0)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(@typechain/ethers-v5@10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(hardhat@2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))':
     dependencies:
       '@ethersproject/abi': 5.6.0
       '@ethersproject/providers': 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
-      '@typechain/ethers-v5': 10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3)
-      ethers: 5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+      '@typechain/ethers-v5': 10.0.0(@ethersproject/abi@5.6.0)(@ethersproject/bytes@5.6.1)(@ethersproject/providers@5.6.2(bufferutil@4.0.6)(utf-8-validate@5.0.9))(ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9))(typechain@8.0.0(supports-color@8.1.1)(typescript@4.6.3))(typescript@4.6.3)
+      ethers: 6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
       fs-extra: 9.1.0
       hardhat: 2.28.6(bufferutil@4.0.6)(supports-color@8.1.1)(ts-node@10.7.0(@types/node@16.11.26)(typescript@4.6.3))(typescript@4.6.3)(utf-8-validate@5.0.9)
       lodash: 4.17.21
@@ -6192,44 +6257,44 @@ snapshots:
 
   '@types/bn.js@4.11.6':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/bn.js@5.1.0':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/chai@4.3.0': {}
 
   '@types/concat-stream@1.6.1':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/form-data@0.0.33':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/glob@7.2.0':
     dependencies:
       '@types/minimatch': 3.0.5
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/js-yaml@4.0.5': {}
 
   '@types/keyv@3.1.4':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/minimatch@3.0.5': {}
 
   '@types/mkdirp@0.5.2':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/mocha@9.1.0': {}
 
   '@types/node-fetch@2.6.1':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
       form-data: 3.0.1
 
   '@types/node@10.17.60': {}
@@ -6238,13 +6303,15 @@ snapshots:
 
   '@types/node@16.11.26': {}
 
-  '@types/node@17.0.23': {}
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/node@8.10.66': {}
 
   '@types/pbkdf2@3.1.0':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/prettier@2.4.4': {}
 
@@ -6252,15 +6319,15 @@ snapshots:
 
   '@types/resolve@0.0.8':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/responselike@1.0.3':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/secp256k1@4.0.3':
     dependencies:
-      '@types/node': 17.0.23
+      '@types/node': 16.11.26
 
   '@types/sinon-chai@3.2.8':
     dependencies:
@@ -6325,6 +6392,8 @@ snapshots:
 
   aes-js@3.1.2:
     optional: true
+
+  aes-js@4.0.0-beta.5: {}
 
   agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
@@ -8295,6 +8364,19 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ethers@6.17.0(bufferutil@4.0.6)(utf-8-validate@5.0.9):
+    dependencies:
+      '@adraffy/ens-normalize': 1.11.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.21.0(bufferutil@4.0.6)(utf-8-validate@5.0.9)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ethjs-abi@0.2.1:
     dependencies:
       bn.js: 4.11.6
@@ -9557,6 +9639,8 @@ snapshots:
   lodash.camelcase@4.3.0: {}
 
   lodash.flatten@4.4.0: {}
+
+  lodash.isequal@4.5.0: {}
 
   lodash.merge@4.6.2: {}
 
@@ -11337,6 +11421,8 @@ snapshots:
 
   tslib@2.3.1: {}
 
+  tslib@2.7.0: {}
+
   tsort@0.0.1: {}
 
   tunnel-agent@0.6.0:
@@ -11435,6 +11521,8 @@ snapshots:
 
   underscore@1.9.1:
     optional: true
+
+  undici-types@6.19.8: {}
 
   undici@5.29.0:
     dependencies:
@@ -12308,6 +12396,11 @@ snapshots:
       utf-8-validate: 5.0.9
 
   ws@7.5.7(bufferutil@4.0.6)(utf-8-validate@5.0.9):
+    optionalDependencies:
+      bufferutil: 4.0.6
+      utf-8-validate: 5.0.9
+
+  ws@8.21.0(bufferutil@4.0.6)(utf-8-validate@5.0.9):
     optionalDependencies:
       bufferutil: 4.0.6
       utf-8-validate: 5.0.9

--- a/scripts/check-parity.js
+++ b/scripts/check-parity.js
@@ -19,6 +19,21 @@ const STAGE_11_INVENTORY_PATH = path.join(
   "compatibility",
   "stage-11-hardhat-smoke-inventory.json"
 );
+const STAGE_12A_INVENTORY_PATH = path.join(
+  ROOT,
+  "compatibility",
+  "stage-12a-ethers6-inventory.json"
+);
+const STAGE_12A_CANDIDATE = "stage-12a-ethers-6";
+const STAGE_12A_BASE_COMMIT = "c84870955d77e82e91ed70591f010233675a6880";
+const STAGE_12A_INVENTORY_SHA256 =
+  "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2";
+const STAGE_11_INVENTORY_SHA256 =
+  "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4";
+const STAGE_11_SMOKE_NAMES_SHA256 =
+  "e82ce4a1063d5334c8a0962747e9bb0797c9e5e82ef6e40dc1905452fb78714f";
+const STAGE_11_SMOKE_SOURCE_SHA256 =
+  "7fe9df8fca7273886e8eb8cbe96cd8053a9d4061c4034cb46a34831b59ae065a";
 const STAGE_11_CANDIDATE = "stage-11-foundry-first-cutover";
 const STAGE_11_BASE_COMMIT = "14720718787046af58be50c110be40c18f5b1364";
 const STAGE_11_HARDHAT_NAMES_SHA256 =
@@ -62,12 +77,18 @@ function stableJson(value) {
   return `${JSON.stringify(value, null, 2)}\n`;
 }
 
+function valuesEqual(left, right) {
+  return JSON.stringify(left) === JSON.stringify(right);
+}
+
 function stage11Inventory(baseline) {
   if (!fs.existsSync(STAGE_11_INVENTORY_PATH)) {
     fail("Missing checked-in Stage 11 Hardhat smoke inventory");
   }
   const inventory = readJson(STAGE_11_INVENTORY_PATH);
   if (
+    sha256(fs.readFileSync(STAGE_11_INVENTORY_PATH)) !==
+      STAGE_11_INVENTORY_SHA256 ||
     inventory.schemaVersion !== 1 ||
     inventory.candidate !== STAGE_11_CANDIDATE ||
     inventory.stage10Checkpoint !== STAGE_11_BASE_COMMIT ||
@@ -78,6 +99,9 @@ function stage11Inventory(baseline) {
     !Array.isArray(inventory.activeHardhat?.names) ||
     inventory.activeHardhat.names.length !== 3 ||
     inventory.activeHardhat.sourcePath !== "tests/Interoperability.smoke.ts" ||
+    inventory.activeHardhat.sourceSha256 !== STAGE_11_SMOKE_SOURCE_SHA256 ||
+    sha256(stableJson(inventory.activeHardhat.names)) !==
+      STAGE_11_SMOKE_NAMES_SHA256 ||
     inventory.forge?.count !== 140 ||
     inventory.forge?.namesSha256 !== STAGE_11_FORGE_NAMES_SHA256 ||
     inventory.parity?.mappedBehaviorCount !== 104 ||
@@ -97,18 +121,6 @@ function stage11Inventory(baseline) {
     fail(
       "Stage 11 Hardhat smoke names must be exactly three unique sorted IDs"
     );
-  }
-  const smokePath = resolveUnder(
-    inventory.activeHardhat.sourcePath,
-    "tests",
-    "Stage 11 Hardhat smoke source"
-  );
-  if (!fs.existsSync(smokePath))
-    fail("Stage 11 Hardhat smoke source is missing");
-  if (
-    sha256(fs.readFileSync(smokePath)) !== inventory.activeHardhat.sourceSha256
-  ) {
-    fail("Stage 11 Hardhat smoke source digest changed");
   }
   if (
     baseline.tests.hardhat.count !== 89 ||
@@ -135,6 +147,74 @@ function stage11Inventory(baseline) {
       sha256(fs.readFileSync(path.join(ROOT, relativePath))) !== expectedSha256
     ) {
       fail(`Frozen parity/safety provenance changed: ${relativePath}`);
+    }
+  }
+  return inventory;
+}
+
+function stage12aInventory(stage11) {
+  if (!fs.existsSync(STAGE_12A_INVENTORY_PATH)) {
+    fail("Missing checked-in Stage 12a ethers 6 smoke/tooling inventory");
+  }
+  const bytes = fs.readFileSync(STAGE_12A_INVENTORY_PATH);
+  const inventory = JSON.parse(bytes);
+  if (
+    sha256(bytes) !== STAGE_12A_INVENTORY_SHA256 ||
+    inventory.schemaVersion !== 1 ||
+    inventory.candidate !== STAGE_12A_CANDIDATE ||
+    inventory.stage11Checkpoint !== STAGE_12A_BASE_COMMIT ||
+    inventory.inheritedStage11?.inventoryPath !==
+      "compatibility/stage-11-hardhat-smoke-inventory.json" ||
+    inventory.inheritedStage11?.inventorySha256 !== STAGE_11_INVENTORY_SHA256 ||
+    inventory.inheritedStage11?.hardhatNamesSha256 !==
+      STAGE_11_SMOKE_NAMES_SHA256 ||
+    inventory.inheritedStage11?.smokeSourceSha256 !==
+      STAGE_11_SMOKE_SOURCE_SHA256 ||
+    inventory.activeHardhat?.count !== 3 ||
+    !valuesEqual(inventory.activeHardhat?.names, stage11.activeHardhat.names) ||
+    inventory.activeHardhat.sourcePath !== "tests/Interoperability.smoke.ts" ||
+    inventory.forge?.count !== 140 ||
+    inventory.forge?.namesSha256 !== STAGE_11_FORGE_NAMES_SHA256 ||
+    inventory.tooling?.hardhat !== "2.28.6" ||
+    inventory.tooling?.ethers !== "6.17.0" ||
+    inventory.tooling?.hardhatEthers !== "3.1.3" ||
+    inventory.parity?.mappedBehaviorCount !== 104 ||
+    inventory.parity?.safetyCount !== 36 ||
+    JSON.stringify(inventory.parity?.files) !==
+      JSON.stringify(STAGE_11_PARITY_FILES)
+  ) {
+    fail("Stage 12a ethers 6 smoke/tooling inventory has an invalid schema");
+  }
+  const smokePath = resolveUnder(
+    inventory.activeHardhat.sourcePath,
+    "tests",
+    "Stage 12a Hardhat smoke source"
+  );
+  if (
+    !fs.existsSync(smokePath) ||
+    sha256(fs.readFileSync(smokePath)) !== inventory.activeHardhat.sourceSha256
+  ) {
+    fail("Stage 12a Hardhat smoke source digest changed");
+  }
+  const expectedToolingFiles = [
+    "hardhat.config.d.ts",
+    "hardhat.config.ts",
+    "package.json",
+    "pnpm-lock.yaml",
+    "tsconfig.json",
+  ];
+  if (
+    JSON.stringify(Object.keys(inventory.tooling.files).sort()) !==
+    JSON.stringify(expectedToolingFiles)
+  ) {
+    fail("Stage 12a tooling inventory paths changed");
+  }
+  for (const relativePath of expectedToolingFiles) {
+    if (
+      sha256(fs.readFileSync(path.join(ROOT, relativePath))) !==
+      inventory.tooling.files[relativePath]
+    ) {
+      fail(`Stage 12a tooling source digest changed: ${relativePath}`);
     }
   }
   return inventory;
@@ -303,6 +383,7 @@ function main() {
   const map = readJson(MAP_PATH);
   const baseline = readJson(BASELINE_PATH);
   const stage11 = stage11Inventory(baseline);
+  const stage12a = stage12aInventory(stage11);
   if (map.schemaVersion !== 1) fail("Unsupported parity-map schema");
   if (!Array.isArray(map.fragments) || map.fragments.length === 0) {
     fail("Parity map must list its cohort fragments");
@@ -479,11 +560,11 @@ function main() {
     executedForgeTests
   );
   if (
-    discoveredForgeTests.length !== stage11.forge.count ||
+    discoveredForgeTests.length !== stage12a.forge.count ||
     sha256(stableJson([...discoveredForgeTests].sort())) !==
-      stage11.forge.namesSha256 ||
+      stage12a.forge.namesSha256 ||
     sha256(stableJson([...executedForgeTests].sort())) !==
-      stage11.forge.namesSha256
+      stage12a.forge.namesSha256
   ) {
     fail("Stage 11 active 140-Forge inventory digest changed");
   }

--- a/scripts/compatibility.js
+++ b/scripts/compatibility.js
@@ -880,6 +880,107 @@ const STAGE_11_FINAL_CHANGED_PATHS = Object.freeze(
     "compatibility/reviewed-differences.json",
   ].sort()
 );
+const STAGE_12A_CANDIDATE = "stage-12a-ethers-6";
+const STAGE_12A_POLICY = "stage-12a-ethers-6-stage-11-equality";
+const STAGE_12A_EVIDENCE_PATH =
+  "compatibility/evidence/stage-12a-ethers-6.json";
+const STAGE_12A_BASE_COMMIT = "c84870955d77e82e91ed70591f010233675a6880";
+const STAGE_12A_STAGE_11_EVIDENCE_SHA256 =
+  "0077542e6ac4c5f1af3813ff8e84dcc4d46182f1a8c0b28e290acfae733da412";
+const STAGE_12A_STAGE_11_REVIEW_SHA256 =
+  "4dfa67856a3d5d04a1057df5064926a07fd1dcde314b05bbdd1927a3080b7731";
+const STAGE_12A_CHECKPOINT_BINDING = Object.freeze({
+  commit: STAGE_12A_BASE_COMMIT,
+  evidence: Object.freeze({
+    path: STAGE_11_EVIDENCE_PATH,
+    sha256: STAGE_12A_STAGE_11_EVIDENCE_SHA256,
+  }),
+  review: Object.freeze({
+    path: "compatibility/reviewed-differences.json",
+    sha256: STAGE_12A_STAGE_11_REVIEW_SHA256,
+  }),
+});
+const STAGE_12A_INVENTORY_PATH =
+  "compatibility/stage-12a-ethers6-inventory.json";
+const STAGE_12A_INVENTORY_SHA256 =
+  "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2";
+const STAGE_12A_ETHERS_VERSION = "6.17.0";
+const STAGE_12A_HARDHAT_ETHERS_VERSION = "3.1.3";
+const STAGE_12A_HARDHAT_VERSION = "2.28.6";
+const STAGE_12A_RETAINED_LEGACY_DEV_DEPENDENCIES = Object.freeze({
+  "@ethersproject/abi": "5.6.0",
+  "@ethersproject/contracts": "5.6.0",
+  "@ethersproject/providers": "5.6.2",
+  "@nomiclabs/hardhat-ethers": "2.0.5",
+  "@nomiclabs/hardhat-waffle": "2.0.3",
+  "@nomiclabs/hardhat-web3": "2.0.0",
+  "@typechain/ethers-v5": "10.0.0",
+  "@typechain/hardhat": "6.0.0",
+  "ethereum-waffle": "3.4.4",
+  typechain: "8.0.0",
+});
+const STAGE_12A_DORMANT_ETHERS5_TOOLING = Object.freeze({
+  "@nomiclabs/hardhat-ethers": "2.0.5",
+  "@nomiclabs/hardhat-waffle": "2.0.3",
+  "@typechain/ethers-v5": "10.0.0",
+  "@typechain/hardhat": "6.0.0",
+  "ethereum-waffle": "3.4.4",
+  typechain: "8.0.0",
+});
+const STAGE_12A_RETAINED_LEGACY_HELPERS = Object.freeze({
+  "@ethersproject/abi": "5.6.0",
+  "@ethersproject/contracts": "5.6.0",
+  "@ethersproject/providers": "5.6.2",
+});
+const STAGE_12A_ACTIVE_LEGACY_PLUGIN = Object.freeze({
+  "@nomiclabs/hardhat-web3": "2.0.0",
+});
+const STAGE_12A_ETHERS_INTEGRITY =
+  "sha512-BpyrpIPJ3ydEVow8zGaz1DuPS7YU8DcWxuBnY9a0UA/lvAPwrMr+EPXsfrul628SRaekPNeIM4UFh/91GWZang==";
+const STAGE_12A_HARDHAT_ETHERS_INTEGRITY =
+  "sha512-208JcDeVIl+7Wu3MhFUUtiA8TJ7r2Rn3Wr+lSx9PfsDTKkbsAsWPY6N6wQ4mtzDv0/pB9nIbJhkjoHe1EsgNsA==";
+const STAGE_12A_LOCKFILE_SHA256 =
+  "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4";
+const STAGE_12A_PACKAGE_SHA256 =
+  "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7";
+const STAGE_12A_EXPECTED_PACKAGE_DIFFERENCE_PATHS = Object.freeze([
+  "$.packageJson.devDependencies.@nomicfoundation/hardhat-ethers",
+  "$.packageJson.devDependencies.ethers",
+  "$.packageJson.scripts.test:hardhat:smoke",
+  "$.packageJson.scripts.typechain",
+]);
+const STAGE_12A_BOUND_FILES = Object.freeze({
+  "compatibility/README.md":
+    "cccac2d4fb89015cdbe20197a9c08d78ecc90c11384d485690b471e42e390df8",
+  "compatibility/stage-12a-ethers6-inventory.json":
+    "f9f3e23ccd84236ffca10d2eb79b3c0f737e83efd0692f8a57ea3a0ac98f0cc2",
+  "docs/development.md":
+    "ab764805a0d8d4679dca1f6b2043ba3f21ea2b5420d567558719a3d5c2109727",
+  "hardhat.config.d.ts":
+    "279ba3be547bf4369a358eafee9bf89d2f6733813010c588f70164512a8158a4",
+  "hardhat.config.ts":
+    "a1fe8c8ee149838e99cd8a93a249a50a1655777589c1341ce6c2e93c8fe1e2ab",
+  "package.json":
+    "fa57c6f6ac2429bcd3b4dcf5c3d8c3121d926999f902baea190488aff854d7a7",
+  "pnpm-lock.yaml":
+    "7ee226b9a5f69123376f1f7429dd7e34b5262c3673a776d1c6cc4ee7ff9e46b4",
+  "scripts/check-parity.js":
+    "540ef384dda01295a357a048290bb89004d3aa64a5e7455b73ff3c08fe37f53a",
+  "tests/Interoperability.smoke.ts":
+    "2cfc8c3fe6599499433874440ed885b19f6ec39e6510eae0c881b19c5aed3350",
+  "tsconfig.json":
+    "79498bc723d15551590dfcc9ce33d2e69f1023895b24d4d680be6c67e97cd488",
+});
+const STAGE_12A_CORE_CHANGED_PATHS = Object.freeze(
+  [...Object.keys(STAGE_12A_BOUND_FILES), "scripts/compatibility.js"].sort()
+);
+const STAGE_12A_FINAL_CHANGED_PATHS = Object.freeze(
+  [
+    ...STAGE_12A_CORE_CHANGED_PATHS,
+    STAGE_12A_EVIDENCE_PATH,
+    "compatibility/reviewed-differences.json",
+  ].sort()
+);
 const PROJECT_REVERT_STRINGS_PATH = path.join(
   ROOT,
   "compatibility",
@@ -1386,6 +1487,33 @@ function validateStage11Candidate(baseline, candidate) {
   stage11LegacyGasEqualityEvidence(candidate, checkpoint);
 }
 
+function validateStage12aCandidate(baseline, candidate) {
+  const checkpoint = stage12aCheckpointAnchor();
+  stage09ForgeStdEvidence();
+  stage12aSourceEvidence(candidate);
+  stage12aTestInventory(candidate, checkpoint);
+  validateSecurity01HardFields(baseline, candidate);
+  if (
+    candidate.compiler.version !== STAGE_08_COMPILER_VERSION ||
+    candidate.compiler.longVersion !== STAGE_08_COMPILER_LONG_VERSION ||
+    !valuesEqual(candidate.compiler.settings, baseline.compiler.settings)
+  ) {
+    throw new Error(
+      "Stage 12a must preserve exact Solidity 0.8.36 and every compiler setting"
+    );
+  }
+  const expectedReverts = security04ProjectRevertStrings(
+    baseline.projectRevertStrings
+  );
+  if (!valuesEqual(candidate.projectRevertStrings, expectedReverts)) {
+    throw new Error(
+      "Stage 12a must preserve every Stage 11 project-owned revert payload, callsite, and ordering"
+    );
+  }
+  stage12aProductionEqualityEvidence(baseline, candidate, checkpoint);
+  stage12aLegacyGasEqualityEvidence(candidate, checkpoint);
+}
+
 const REVIEW_POLICIES = Object.freeze({
   "stage-04-source-path-metadata-and-gas": Object.freeze({
     candidate: "stage-04-package-canonical-openzeppelin",
@@ -1715,6 +1843,25 @@ const REVIEW_POLICIES = Object.freeze({
       );
     },
     validateCandidate: validateStage11Candidate,
+  }),
+  [STAGE_12A_POLICY]: Object.freeze({
+    candidate: STAGE_12A_CANDIDATE,
+    requiredOpcodeEvidence: Object.freeze({
+      mode: "stage-12a-stage-11-production-equality",
+      path: STAGE_12A_EVIDENCE_PATH,
+      contracts: STAGE_08_PRODUCTION_CONTRACTS,
+    }),
+    requiredSafetyEvidence: Object.freeze({
+      path: "compatibility/evidence/stage-07-safety-artifacts.json",
+      sha256:
+        "0065814caec6e3044951f80c891c9948454e90138d016513ed07d0fcfb7c67d8",
+    }),
+    requiredStage11Checkpoint: STAGE_12A_CHECKPOINT_BINDING,
+    requiresStage12aMigrationEvidence: true,
+    permits() {
+      return false;
+    },
+    validateCandidate: validateStage12aCandidate,
   }),
 });
 
@@ -3147,6 +3294,426 @@ function stage11SourceEvidence(candidate) {
   });
 }
 
+function validateStage12aFrozenConstants() {
+  if (
+    STAGE_12A_ETHERS_INTEGRITY === "TO_BE_FROZEN" ||
+    STAGE_12A_HARDHAT_ETHERS_INTEGRITY === "TO_BE_FROZEN" ||
+    STAGE_12A_LOCKFILE_SHA256 === "TO_BE_FROZEN" ||
+    STAGE_12A_PACKAGE_SHA256 === "TO_BE_FROZEN" ||
+    STAGE_12A_EXPECTED_PACKAGE_DIFFERENCE_PATHS.length === 0 ||
+    Object.keys(STAGE_12A_BOUND_FILES).length === 0 ||
+    STAGE_12A_CORE_CHANGED_PATHS.length === 0 ||
+    STAGE_12A_FINAL_CHANGED_PATHS.length === 0
+  ) {
+    throw new Error(
+      "Stage 12a candidate provenance has not been frozen after the ethers 6 migration settled"
+    );
+  }
+}
+
+function validateStage12aChangedPaths(actual) {
+  validateStage12aFrozenConstants();
+  const permittedStates = [
+    STAGE_12A_CORE_CHANGED_PATHS,
+    [
+      ...STAGE_12A_CORE_CHANGED_PATHS,
+      "compatibility/reviewed-differences.json",
+    ],
+    STAGE_12A_FINAL_CHANGED_PATHS,
+  ].map((paths) => [...new Set(paths)].sort());
+  const normalized = [...new Set(actual)].sort();
+  if (!permittedStates.some((expected) => valuesEqual(normalized, expected))) {
+    const differences = collectDifferences(
+      STAGE_12A_FINAL_CHANGED_PATHS,
+      normalized,
+      "$.stage12aChangedPaths"
+    );
+    throw new Error(
+      `Stage 12a repository changes differ from its exact core/review/evidence states:\n${differences
+        .slice(0, 30)
+        .map((difference) => `- ${formatDifference(difference)}`)
+        .join("\n")}`
+    );
+  }
+  return [...STAGE_12A_FINAL_CHANGED_PATHS];
+}
+
+function stage12aBoundFileEvidence() {
+  validateStage12aFrozenConstants();
+  const files = fileDigestEvidence(STAGE_12A_BOUND_FILES);
+  validateExactFileDigests(files, STAGE_12A_BOUND_FILES, "stage12aFiles");
+  return files;
+}
+
+function stage12aToolingInventory(checkpoint = stage12aCheckpointAnchor()) {
+  const inventoryPath = path.join(ROOT, STAGE_12A_INVENTORY_PATH);
+  const bytes = fs.readFileSync(inventoryPath);
+  const inventory = JSON.parse(bytes);
+  const expectedHardhat =
+    checkpoint.evidence.value.sourceAndTestCutover.tests.activeHardhat;
+  if (
+    sha256(bytes) !== STAGE_12A_INVENTORY_SHA256 ||
+    inventory.schemaVersion !== 1 ||
+    inventory.candidate !== STAGE_12A_CANDIDATE ||
+    inventory.stage11Checkpoint !== STAGE_12A_BASE_COMMIT ||
+    inventory.inheritedStage11?.inventoryPath !==
+      STAGE_11_SMOKE_INVENTORY_PATH ||
+    inventory.inheritedStage11?.inventorySha256 !==
+      "abea926d3e3cf7928a7693565aa01c2e59c22e442ce97c4a0271c7be46095cf4" ||
+    inventory.inheritedStage11?.hardhatNamesSha256 !==
+      sha256(stableJson(expectedHardhat.names)) ||
+    inventory.inheritedStage11?.smokeSourceSha256 !==
+      checkpoint.evidence.value.sourceAndTestCutover.tests.smokeInventory
+        .activeHardhat.sourceSha256 ||
+    !valuesEqual(inventory.activeHardhat.names, expectedHardhat.names) ||
+    inventory.activeHardhat.count !== expectedHardhat.count ||
+    inventory.activeHardhat.sourcePath !== "tests/Interoperability.smoke.ts" ||
+    inventory.forge?.count !== STAGE_11_FORGE_COUNT ||
+    inventory.forge?.namesSha256 !== STAGE_11_FORGE_NAMES_SHA256 ||
+    inventory.tooling?.hardhat !== STAGE_12A_HARDHAT_VERSION ||
+    inventory.tooling?.ethers !== STAGE_12A_ETHERS_VERSION ||
+    inventory.tooling?.hardhatEthers !== STAGE_12A_HARDHAT_ETHERS_VERSION ||
+    inventory.parity?.mappedBehaviorCount !== 104 ||
+    inventory.parity?.safetyCount !== 36 ||
+    !valuesEqual(inventory.parity?.files, security01ParityEvidence())
+  ) {
+    throw new Error("Stage 12a ethers 6 smoke/tooling inventory is invalid");
+  }
+  const sourceBytes = fs.readFileSync(
+    path.join(ROOT, inventory.activeHardhat.sourcePath)
+  );
+  if (sha256(sourceBytes) !== inventory.activeHardhat.sourceSha256) {
+    throw new Error("Stage 12a ethers 6 smoke source digest changed");
+  }
+  const expectedToolingPaths = [
+    "hardhat.config.d.ts",
+    "hardhat.config.ts",
+    "package.json",
+    "pnpm-lock.yaml",
+    "tsconfig.json",
+  ];
+  if (
+    !valuesEqual(
+      Object.keys(inventory.tooling.files).sort(),
+      expectedToolingPaths
+    )
+  ) {
+    throw new Error("Stage 12a tooling inventory paths changed");
+  }
+  for (const relativePath of expectedToolingPaths) {
+    if (
+      sha256(fs.readFileSync(path.join(ROOT, relativePath))) !==
+      inventory.tooling.files[relativePath]
+    ) {
+      throw new Error(`Stage 12a tooling digest changed: ${relativePath}`);
+    }
+  }
+  return sorted({
+    ...inventory,
+    path: STAGE_12A_INVENTORY_PATH,
+    sha256: sha256(bytes),
+  });
+}
+
+function stage12aTestInventory(
+  candidate,
+  checkpoint = stage12aCheckpointAnchor()
+) {
+  const toolingInventory = stage12aToolingInventory(checkpoint);
+  const expectedHardhat =
+    checkpoint.evidence.value.sourceAndTestCutover.tests.activeHardhat;
+  const parity = stage06ParityForgeTests();
+  const safety = stage07SafetyForgeTests();
+  const expectedForgeNames = [...parity.forgeNames, ...safety].sort();
+  if (
+    expectedHardhat.count !== 3 ||
+    expectedHardhat.names.length !== 3 ||
+    sha256(stableJson(expectedHardhat.names)) !==
+      sha256(stableJson(candidate.tests.hardhat.names)) ||
+    !valuesEqual(candidate.tests.hardhat, expectedHardhat) ||
+    !valuesEqual(
+      candidate.tests.hardhat.names,
+      toolingInventory.activeHardhat.names
+    ) ||
+    expectedForgeNames.length !== STAGE_11_FORGE_COUNT ||
+    sha256(stableJson(expectedForgeNames)) !== STAGE_11_FORGE_NAMES_SHA256 ||
+    !valuesEqual(candidate.tests.forge.names, expectedForgeNames) ||
+    candidate.tests.forge.count !== STAGE_11_FORGE_COUNT ||
+    candidate.tests.total !== 3 + STAGE_11_FORGE_COUNT
+  ) {
+    throw new Error(
+      "Stage 12a must preserve exactly the three Stage 11 Hardhat smokes and all 140 Forge identifiers"
+    );
+  }
+  return sorted({
+    hardhat: {
+      count: candidate.tests.hardhat.count,
+      names: candidate.tests.hardhat.names,
+      namesSha256: sha256(stableJson(candidate.tests.hardhat.names)),
+    },
+    forge: {
+      count: candidate.tests.forge.count,
+      namesSha256: sha256(stableJson(candidate.tests.forge.names)),
+      mappedBehaviorCount: parity.forgeNames.length,
+      safetyCount: safety.length,
+    },
+    total: candidate.tests.total,
+    toolingInventory,
+  });
+}
+
+function stage12aProductionSourceEquality(checkpoint) {
+  const expected =
+    checkpoint.evidence.value.sourceAndTestCutover.productionSources;
+  const sources = {};
+  for (const relativePath of STAGE_10_PRODUCTION_SOURCES) {
+    const actualSha256 = sha256(fs.readFileSync(path.join(ROOT, relativePath)));
+    const expectedSha256 = expected[relativePath]?.sha256;
+    if (!expectedSha256 || actualSha256 !== expectedSha256) {
+      throw new Error(
+        `Stage 12a production source differs from Stage 11: ${relativePath}`
+      );
+    }
+    sources[relativePath] = { sha256: actualSha256, equal: true };
+  }
+  return sorted(sources);
+}
+
+function stage12aCompilerSourceEquality(checkpoint) {
+  const expected =
+    checkpoint.evidence.value.sourceAndTestCutover.compilerSources;
+  const sourceHashes = compilerSourceHashes();
+  const names = Object.keys(sourceHashes).sort();
+  const actual = {
+    sourceCount: names.length,
+    sourceNamesSha256: sha256(stableJson(names)),
+    candidateClosureSha256: sha256(stableJson(sourceHashes)),
+    completeSourceHashes: sourceHashes,
+    productionImportClosure: stage10ProductionImportClosure(sourceHashes),
+  };
+  for (const field of [
+    "sourceCount",
+    "sourceNamesSha256",
+    "candidateClosureSha256",
+    "completeSourceHashes",
+    "productionImportClosure",
+  ]) {
+    if (!valuesEqual(actual[field], expected[field])) {
+      throw new Error(`Stage 12a compiler source closure changed: ${field}`);
+    }
+  }
+  return sorted({ ...actual, equalToStage11: true });
+}
+
+function stage12aBasePackageJson() {
+  return JSON.parse(
+    run("git", ["show", `${STAGE_12A_BASE_COMMIT}:package.json`]).stdout
+  );
+}
+
+function validateStage12aPackageManifest(packageJson) {
+  validateStage12aFrozenConstants();
+  const base = stage12aBasePackageJson();
+  if (
+    base.devDependencies?.ethers !== "5.6.2" ||
+    base.devDependencies?.["@nomiclabs/hardhat-ethers"] !== "2.0.5" ||
+    base.devDependencies?.hardhat !== STAGE_12A_HARDHAT_VERSION
+  ) {
+    throw new Error(
+      "Stage 12a inherited an invalid Stage 11 JS dependency set"
+    );
+  }
+  if (
+    packageJson.devDependencies?.ethers !== STAGE_12A_ETHERS_VERSION ||
+    packageJson.devDependencies?.["@nomicfoundation/hardhat-ethers"] !==
+      STAGE_12A_HARDHAT_ETHERS_VERSION ||
+    packageJson.devDependencies?.hardhat !== STAGE_12A_HARDHAT_VERSION ||
+    !valuesEqual(packageJson.dependencies, base.dependencies)
+  ) {
+    throw new Error(
+      "Stage 12a requires exact ethers 6.17.0, Foundation hardhat-ethers 3.1.3, Hardhat 2.28.6, and unchanged runtime dependencies"
+    );
+  }
+  for (const [name, version] of Object.entries(
+    STAGE_12A_RETAINED_LEGACY_DEV_DEPENDENCIES
+  )) {
+    if (
+      base.devDependencies?.[name] !== version ||
+      packageJson.devDependencies?.[name] !== version
+    ) {
+      throw new Error(
+        `Stage 12a must retain dormant legacy dependency ${name}@${version} unchanged for the isolated Stage 12b removal`
+      );
+    }
+  }
+  const differences = collectDifferences(base, packageJson, "$.packageJson");
+  const actualPaths = differences.map(({ path: reviewPath }) => reviewPath);
+  if (!valuesEqual(actualPaths, STAGE_12A_EXPECTED_PACKAGE_DIFFERENCE_PATHS)) {
+    throw new Error(
+      `Stage 12a package.json changed outside its exact migration:\n${collectDifferences(
+        STAGE_12A_EXPECTED_PACKAGE_DIFFERENCE_PATHS,
+        actualPaths,
+        "$.packageDifferencePaths"
+      )
+        .map((difference) => `- ${formatDifference(difference)}`)
+        .join("\n")}`
+    );
+  }
+  return differences;
+}
+
+function lockfileKey(name) {
+  return name.startsWith("@") ? `'${name}'` : name;
+}
+
+function escapedPattern(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function validateStage12aLockDependency(lock, name, version, integrity) {
+  const key = escapedPattern(lockfileKey(name));
+  const escapedVersion = escapedPattern(version);
+  const escapedIntegrity = escapedPattern(integrity);
+  const importer = new RegExp(
+    `^      ${key}:\\n        specifier: ${escapedVersion}\\n        version: ${escapedVersion}(?:\\([^\\n]+\\))?$`,
+    "m"
+  );
+  const resolution = new RegExp(
+    `^  ${escapedPattern(
+      lockfileKey(`${name}@${version}`)
+    )}:\\n    resolution: \\{integrity: ${escapedIntegrity}\\}`,
+    "m"
+  );
+  if (!importer.test(lock) || !resolution.test(lock)) {
+    throw new Error(
+      `Stage 12a pnpm lock is missing exact ${name} ${version} importer/integrity evidence`
+    );
+  }
+}
+
+function stage12aDependencyEvidence() {
+  validateStage12aFrozenConstants();
+  const packagePath = path.join(ROOT, "package.json");
+  const lockPath = path.join(ROOT, "pnpm-lock.yaml");
+  const packageBytes = fs.readFileSync(packagePath);
+  const lockBytes = fs.readFileSync(lockPath);
+  const packageJson = JSON.parse(packageBytes);
+  const lock = lockBytes.toString("utf8");
+  const differences = validateStage12aPackageManifest(packageJson);
+  if (
+    sha256(packageBytes) !== STAGE_12A_PACKAGE_SHA256 ||
+    sha256(lockBytes) !== STAGE_12A_LOCKFILE_SHA256
+  ) {
+    throw new Error("Stage 12a package manifest or lockfile digest changed");
+  }
+  validateStage12aLockDependency(
+    lock,
+    "ethers",
+    STAGE_12A_ETHERS_VERSION,
+    STAGE_12A_ETHERS_INTEGRITY
+  );
+  validateStage12aLockDependency(
+    lock,
+    "@nomicfoundation/hardhat-ethers",
+    STAGE_12A_HARDHAT_ETHERS_VERSION,
+    STAGE_12A_HARDHAT_ETHERS_INTEGRITY
+  );
+  if (!/^      '@nomiclabs\/hardhat-ethers':$/m.test(lock)) {
+    throw new Error(
+      "Stage 12a must retain the dormant ethers-5 plugin as explicit Stage 12b debt"
+    );
+  }
+  const installed = {};
+  for (const [name, expectedVersion] of [
+    ["ethers", STAGE_12A_ETHERS_VERSION],
+    ["@nomicfoundation/hardhat-ethers", STAGE_12A_HARDHAT_ETHERS_VERSION],
+    ["hardhat", STAGE_12A_HARDHAT_VERSION],
+  ]) {
+    const installedPath = path.join(ROOT, "node_modules", name, "package.json");
+    const installedBytes = fs.readFileSync(installedPath);
+    const installedPackage = JSON.parse(installedBytes);
+    if (installedPackage.version !== expectedVersion) {
+      throw new Error(
+        `Stage 12a installed ${name} version changed: ${installedPackage.version}`
+      );
+    }
+    installed[name] = {
+      version: installedPackage.version,
+      packageJsonSha256: sha256(installedBytes),
+    };
+  }
+  const checkpoint = stage12aCheckpointAnchor();
+  const stage11OpenZeppelin =
+    checkpoint.evidence.value.sourceAndTestCutover.dependency;
+  const openZeppelin = stage10DependencyEvidence();
+  for (const field of [
+    "name",
+    "candidateVersion",
+    "registryIntegrity",
+    "installedPackageJsonSha256",
+  ]) {
+    const checkpointField = field === "candidateVersion" ? "version" : field;
+    if (openZeppelin[field] !== stage11OpenZeppelin[checkpointField]) {
+      throw new Error(`Stage 12a OpenZeppelin dependency changed: ${field}`);
+    }
+  }
+  return sorted({
+    transition: {
+      ethers: { stage11: "5.6.2", candidate: STAGE_12A_ETHERS_VERSION },
+      hardhatEthers: {
+        stage11: { name: "@nomiclabs/hardhat-ethers", version: "2.0.5" },
+        candidate: {
+          name: "@nomicfoundation/hardhat-ethers",
+          version: STAGE_12A_HARDHAT_ETHERS_VERSION,
+        },
+      },
+      hardhat: {
+        stage11: STAGE_12A_HARDHAT_VERSION,
+        candidate: STAGE_12A_HARDHAT_VERSION,
+      },
+      dormantEthers5Tooling: STAGE_12A_DORMANT_ETHERS5_TOOLING,
+      retainedLegacyHelpers: STAGE_12A_RETAINED_LEGACY_HELPERS,
+      unchangedActiveLegacyPlugin: STAGE_12A_ACTIVE_LEGACY_PLUGIN,
+      peerDebtDisposition:
+        "retained but runtime-deactivated without suppression; remove together in Stage 12b",
+      packageDifferences: differences,
+    },
+    registryIntegrity: {
+      ethers: STAGE_12A_ETHERS_INTEGRITY,
+      hardhatEthers: STAGE_12A_HARDHAT_ETHERS_INTEGRITY,
+    },
+    packageJsonSha256: sha256(packageBytes),
+    lockfileSha256: sha256(lockBytes),
+    installed,
+    openZeppelin: {
+      version: openZeppelin.candidateVersion,
+      registryIntegrity: openZeppelin.registryIntegrity,
+      installedPackageJsonSha256: openZeppelin.installedPackageJsonSha256,
+      equalToStage11: true,
+    },
+  });
+}
+
+function stage12aSourceEvidence(candidate) {
+  const checkpoint = stage12aCheckpointAnchor();
+  return sorted({
+    checkpoint: STAGE_12A_CHECKPOINT_BINDING,
+    changedPaths: validateStage12aChangedPaths(
+      repositoryChangedPaths(STAGE_12A_BASE_COMMIT)
+    ),
+    boundFiles: stage12aBoundFileEvidence(),
+    toolingInventory: stage12aToolingInventory(checkpoint),
+    dependencyMigration: stage12aDependencyEvidence(),
+    runtimeBridge: stage12aRuntimeBridgeEvidence(),
+    productionSources: stage12aProductionSourceEquality(checkpoint),
+    compilerSources: stage12aCompilerSourceEquality(checkpoint),
+    tests: stage12aTestInventory(candidate, checkpoint),
+    compatibilityRunnerSha256: sha256(
+      fs.readFileSync(path.join(ROOT, "scripts", "compatibility.js"))
+    ),
+  });
+}
+
 function validateSecurity01CompilerSourceEvidence(evidence) {
   if (
     evidence.sourceCount !== SECURITY_01_COMPILER_SOURCE_COUNT ||
@@ -4416,9 +4983,19 @@ function temporaryFile(name) {
 function captureHardhatTests() {
   const outputPath = temporaryFile("hardhat-tests.json");
   try {
-    run(hardhatBinary(), ["--config", HARDHAT_CONFIG, "test", "--no-compile"], {
-      env: { COMPAT_HARDHAT_RESULTS: outputPath },
-    });
+    run(
+      hardhatBinary(),
+      [
+        "--config",
+        HARDHAT_CONFIG,
+        "test",
+        "tests/Interoperability.smoke.ts",
+        "--no-compile",
+      ],
+      {
+        env: { COMPAT_HARDHAT_RESULTS: outputPath },
+      }
+    );
     const results = JSON.parse(fs.readFileSync(outputPath, "utf8"));
     if (results.failed.length > 0 || results.pending.length > 0) {
       throw new Error(
@@ -4847,6 +5424,14 @@ function reviewPolicy(review) {
       );
     }
   }
+  if (policy.requiredStage11Checkpoint) {
+    const supplied = review.stage11Checkpoint;
+    if (!supplied || !valuesEqual(supplied, policy.requiredStage11Checkpoint)) {
+      throw new Error(
+        `Compatibility review policy ${review.policy} requires the exact Stage 11 checkpoint`
+      );
+    }
+  }
   if (policy.requiresStage10ReceiverEvidence) {
     const expected = stage10ReceiverReviewEvidence();
     if (!valuesEqual(review.receiverEvidence, expected)) {
@@ -4860,6 +5445,14 @@ function reviewPolicy(review) {
     if (!valuesEqual(review.smokeEvidence, expected)) {
       throw new Error(
         `Compatibility review policy ${review.policy} requires the exact Stage 11 Hardhat smoke inventory and source evidence`
+      );
+    }
+  }
+  if (policy.requiresStage12aMigrationEvidence) {
+    const expected = stage12aMigrationReviewEvidence();
+    if (!valuesEqual(review.migrationEvidence, expected)) {
+      throw new Error(
+        `Compatibility review policy ${review.policy} requires the exact Stage 12a dependency, config, and smoke migration evidence`
       );
     }
   }
@@ -5342,6 +5935,120 @@ function stage11Review(baselineBytes, differences, candidate) {
     },
     stage10Checkpoint: STAGE_11_CHECKPOINT_BINDING,
     smokeEvidence: stage11SmokeReviewEvidence(),
+    safetyEvidence: {
+      path: "compatibility/evidence/stage-07-safety-artifacts.json",
+      sha256:
+        "0065814caec6e3044951f80c891c9948454e90138d016513ed07d0fcfb7c67d8",
+    },
+  };
+}
+
+function stage12aRuntimeBridgeEvidence() {
+  const configPath = path.join(ROOT, "hardhat.config.ts");
+  const declarationsPath = path.join(ROOT, "hardhat.config.d.ts");
+  const tsconfigPath = path.join(ROOT, "tsconfig.json");
+  const smokePath = path.join(ROOT, "tests", "Interoperability.smoke.ts");
+  const packagePath = path.join(ROOT, "package.json");
+  const config = fs.readFileSync(configPath, "utf8");
+  const declarations = fs.readFileSync(declarationsPath, "utf8");
+  const tsconfig = JSON.parse(fs.readFileSync(tsconfigPath, "utf8"));
+  const packageJson = JSON.parse(fs.readFileSync(packagePath, "utf8"));
+  const smoke = fs.readFileSync(smokePath, "utf8");
+  const forbiddenRuntimeLoads = [
+    "@nomiclabs/hardhat-ethers",
+    "@nomiclabs/hardhat-waffle",
+    "@typechain/hardhat",
+  ];
+  if (
+    !config.includes('import "@nomicfoundation/hardhat-ethers";') ||
+    forbiddenRuntimeLoads.some((name) => config.includes(name)) ||
+    /\btypechain\s*:/.test(config) ||
+    !declarations.includes("@nomicfoundation/hardhat-ethers") ||
+    forbiddenRuntimeLoads.some((name) => declarations.includes(name)) ||
+    !valuesEqual(tsconfig.include, [
+      "./scripts",
+      "./tests/Interoperability.smoke.ts",
+    ]) ||
+    packageJson.scripts?.["test:hardhat:smoke"] !==
+      "hardhat --network hardhat test tests/Interoperability.smoke.ts" ||
+    Object.prototype.hasOwnProperty.call(
+      packageJson.scripts || {},
+      "typechain"
+    ) ||
+    !smoke.includes('import { ethers, network } from "hardhat";')
+  ) {
+    throw new Error(
+      "Stage 12a Hardhat bridge must load only the Foundation ethers plugin, deactivate Waffle/NomicLabs/TypeChain runtime hooks, scope TypeScript to the smoke, and run the smoke without TypeChain"
+    );
+  }
+  return sorted({
+    active: {
+      hardhat: STAGE_12A_HARDHAT_VERSION,
+      ethers: STAGE_12A_ETHERS_VERSION,
+      plugin: {
+        name: "@nomicfoundation/hardhat-ethers",
+        version: STAGE_12A_HARDHAT_ETHERS_VERSION,
+      },
+    },
+    dormantEthers5Tooling: STAGE_12A_DORMANT_ETHERS5_TOOLING,
+    retainedLegacyHelpers: STAGE_12A_RETAINED_LEGACY_HELPERS,
+    deactivatedHardhatRuntimeHooks: forbiddenRuntimeLoads,
+    unchangedActiveLegacyPlugin: STAGE_12A_ACTIVE_LEGACY_PLUGIN,
+    files: fileDigestEvidence({
+      "hardhat.config.d.ts": STAGE_12A_BOUND_FILES["hardhat.config.d.ts"],
+      "hardhat.config.ts": STAGE_12A_BOUND_FILES["hardhat.config.ts"],
+      "tests/Interoperability.smoke.ts":
+        STAGE_12A_BOUND_FILES["tests/Interoperability.smoke.ts"],
+      "tsconfig.json": STAGE_12A_BOUND_FILES["tsconfig.json"],
+    }),
+    smokeRunner: packageJson.scripts["test:hardhat:smoke"],
+    typeScriptInclude: tsconfig.include,
+  });
+}
+
+function stage12aMigrationReviewEvidence() {
+  const checkpoint = stage12aCheckpointAnchor();
+  return sorted({
+    checkpoint: STAGE_12A_CHECKPOINT_BINDING,
+    boundFiles: stage12aBoundFileEvidence(),
+    toolingInventory: stage12aToolingInventory(checkpoint),
+    dependencyMigration: stage12aDependencyEvidence(),
+    runtimeBridge: stage12aRuntimeBridgeEvidence(),
+    retainedTests: {
+      hardhat:
+        checkpoint.evidence.value.sourceAndTestCutover.tests.activeHardhat,
+      forge: {
+        count: STAGE_11_FORGE_COUNT,
+        namesSha256: STAGE_11_FORGE_NAMES_SHA256,
+      },
+    },
+  });
+}
+
+function stage12aReview(baselineBytes, differences, candidate) {
+  const checkpoint = stage12aCheckpointAnchor();
+  stage12aTestInventory(candidate, checkpoint);
+  if (differences.length !== 0) {
+    throw new Error(
+      `Stage 12a may not review any compatibility-manifest difference:\n${differences
+        .slice(0, 20)
+        .map((difference) => `- ${formatDifference(difference)}`)
+        .join("\n")}`
+    );
+  }
+  return {
+    schemaVersion: 1,
+    candidate: STAGE_12A_CANDIDATE,
+    policy: STAGE_12A_POLICY,
+    baselineSha256: sha256(baselineBytes),
+    allowedDifferences: [],
+    opcodeEvidence: {
+      mode: "stage-12a-stage-11-production-equality",
+      path: STAGE_12A_EVIDENCE_PATH,
+      contracts: [...STAGE_08_PRODUCTION_CONTRACTS],
+    },
+    stage11Checkpoint: STAGE_12A_CHECKPOINT_BINDING,
+    migrationEvidence: stage12aMigrationReviewEvidence(),
     safetyEvidence: {
       path: "compatibility/evidence/stage-07-safety-artifacts.json",
       sha256:
@@ -5970,6 +6677,62 @@ function stage11CheckpointAnchor() {
   };
 }
 
+function stage12aCheckpointAnchor() {
+  run("git", ["merge-base", "--is-ancestor", STAGE_12A_BASE_COMMIT, "HEAD"]);
+  const evidenceBytes = Buffer.from(
+    run("git", ["show", `${STAGE_12A_BASE_COMMIT}:${STAGE_11_EVIDENCE_PATH}`])
+      .stdout
+  );
+  const evidenceSha256 = sha256(evidenceBytes);
+  if (evidenceSha256 !== STAGE_12A_STAGE_11_EVIDENCE_SHA256) {
+    throw new Error(
+      `Stage 12a Stage 11 checkpoint evidence changed: expected ${STAGE_12A_STAGE_11_EVIDENCE_SHA256}, received ${evidenceSha256}`
+    );
+  }
+  const evidence = JSON.parse(evidenceBytes);
+  if (
+    evidence.schemaVersion !== 1 ||
+    evidence.candidate !== STAGE_11_CANDIDATE ||
+    evidence.mode !== "stage-11-stage-10-production-equality"
+  ) {
+    throw new Error("Stage 12a Stage 11 evidence has an invalid identity");
+  }
+  const reviewBytes = Buffer.from(
+    run("git", [
+      "show",
+      `${STAGE_12A_BASE_COMMIT}:compatibility/reviewed-differences.json`,
+    ]).stdout
+  );
+  const reviewSha256 = sha256(reviewBytes);
+  if (reviewSha256 !== STAGE_12A_STAGE_11_REVIEW_SHA256) {
+    throw new Error(
+      `Stage 12a Stage 11 checkpoint review changed: expected ${STAGE_12A_STAGE_11_REVIEW_SHA256}, received ${reviewSha256}`
+    );
+  }
+  const review = JSON.parse(reviewBytes);
+  if (
+    review.schemaVersion !== 1 ||
+    review.candidate !== STAGE_11_CANDIDATE ||
+    review.policy !== STAGE_11_POLICY ||
+    review.opcodeEvidence?.path !== STAGE_11_EVIDENCE_PATH
+  ) {
+    throw new Error("Stage 12a Stage 11 review has an invalid identity");
+  }
+  return {
+    commit: STAGE_12A_BASE_COMMIT,
+    evidence: {
+      path: STAGE_11_EVIDENCE_PATH,
+      sha256: evidenceSha256,
+      value: evidence,
+    },
+    review: {
+      path: "compatibility/reviewed-differences.json",
+      sha256: reviewSha256,
+      value: review,
+    },
+  };
+}
+
 function applyUnifiedOpcodeDiff(baselineOpcodes, diff) {
   if (!diff) return baselineOpcodes;
   const baseline = opcodeInstructions(baselineOpcodes);
@@ -6423,6 +7186,59 @@ function stage10CheckpointLegacyGasEntries(checkpoint) {
     throw new Error("Stage 11 Stage 10 legacy gas digest changed");
   }
   return previousEntries;
+}
+
+function stage12aCheckpointOpcodes(
+  baseline,
+  qualifiedName,
+  bytecodeKind,
+  checkpoint
+) {
+  const stage10 = stage11CheckpointAnchor();
+  const opcodes = stage10CheckpointOpcodes(
+    baseline,
+    qualifiedName,
+    bytecodeKind,
+    stage10
+  );
+  const expected =
+    checkpoint.evidence.value.productionEquality.contracts[qualifiedName][
+      bytecodeKind
+    ].candidate.metadataStrippedOpcodesSha256;
+  if (sha256(opcodes) !== expected) {
+    throw new Error(
+      `Stage 12a could not reconstruct Stage 11 ${qualifiedName} ${bytecodeKind} opcodes`
+    );
+  }
+  return opcodes;
+}
+
+function stage12aCheckpointBytecode(checkpoint, qualifiedName, bytecodeKind) {
+  const bytecode =
+    checkpoint.evidence.value.productionEquality.contracts[qualifiedName][
+      bytecodeKind
+    ];
+  if (!bytecode.equal || !valuesEqual(bytecode.stage10, bytecode.candidate)) {
+    throw new Error(
+      `Stage 12a inherited invalid Stage 11 bytecode equality for ${qualifiedName} ${bytecodeKind}`
+    );
+  }
+  return deepClone(bytecode.candidate);
+}
+
+function stage12aCheckpointLegacyGasEntries(checkpoint) {
+  const entries = stage10CheckpointLegacyGasEntries(stage11CheckpointAnchor());
+  const evidence = checkpoint.evidence.value.legacyGasEquality;
+  if (
+    !evidence.equal ||
+    evidence.fuzzSeed !== "0x721" ||
+    evidence.inventoryCount !== entries.length ||
+    evidence.stage10EntriesSha256 !== sha256(stableJson(entries)) ||
+    evidence.candidateEntriesSha256 !== sha256(stableJson(entries))
+  ) {
+    throw new Error("Stage 12a inherited invalid Stage 11 legacy gas equality");
+  }
+  return entries;
 }
 
 function stage09ProductionEvidence(baseline, candidate) {
@@ -8351,6 +9167,229 @@ function stage11Evidence(review, baseline, candidate) {
   });
 }
 
+function stage12aHardCompatibilityEvidence(baseline, candidate, checkpoint) {
+  const contracts = {};
+  for (const qualifiedName of Object.keys(baseline.contracts).sort()) {
+    const fields = {};
+    for (const field of [
+      "abi",
+      "functions",
+      "events",
+      "errors",
+      "storageLayout",
+    ]) {
+      const expected = baseline.contracts[qualifiedName][field];
+      const actual = candidate.contracts[qualifiedName]?.[field];
+      if (!valuesEqual(actual, expected)) {
+        throw new Error(
+          `Stage 12a hard compatibility changed: ${qualifiedName} ${field}`
+        );
+      }
+      fields[field] = { equal: true, sha256: sha256(stableJson(actual)) };
+    }
+    contracts[qualifiedName] = fields;
+  }
+  const globals = {};
+  for (const field of ["interfaces", "enums", "erc165"]) {
+    if (!valuesEqual(candidate[field], baseline[field])) {
+      throw new Error(`Stage 12a hard compatibility changed: ${field}`);
+    }
+    globals[field] = {
+      equal: true,
+      sha256: sha256(stableJson(candidate[field])),
+    };
+  }
+  const expectedReverts = security04ProjectRevertStrings(
+    baseline.projectRevertStrings
+  );
+  if (!valuesEqual(candidate.projectRevertStrings, expectedReverts)) {
+    throw new Error("Stage 12a project-owned revert evidence changed");
+  }
+  return sorted({
+    contracts,
+    ...globals,
+    compilerSettings: {
+      equal: valuesEqual(
+        candidate.compiler.settings,
+        baseline.compiler.settings
+      ),
+      sha256: sha256(stableJson(candidate.compiler.settings)),
+    },
+    projectRevertStrings: {
+      equal: true,
+      count: candidate.projectRevertStrings.length,
+      sha256: sha256(stableJson(candidate.projectRevertStrings)),
+    },
+    tests: stage12aTestInventory(candidate, checkpoint),
+    parityFiles: security01ParityEvidence(),
+  });
+}
+
+function stage12aProductionEqualityEvidence(baseline, candidate, checkpoint) {
+  const contracts = {};
+  for (const qualifiedName of STAGE_08_PRODUCTION_CONTRACTS) {
+    const candidateContract = candidate.contracts[qualifiedName];
+    const bytecodes = {};
+    for (const bytecodeKind of ["creationBytecode", "runtimeBytecode"]) {
+      const expected = stage12aCheckpointBytecode(
+        checkpoint,
+        qualifiedName,
+        bytecodeKind
+      );
+      const expectedOpcodes = stage12aCheckpointOpcodes(
+        baseline,
+        qualifiedName,
+        bytecodeKind,
+        checkpoint
+      );
+      const actualBytecode = candidateContract[bytecodeKind];
+      const actual = {
+        rawKeccak256: actualBytecode.keccak256,
+        rawSizeBytes: actualBytecode.sizeBytes,
+        metadataBytes: actualBytecode.metadataBytes,
+        metadataStrippedKeccak256: actualBytecode.metadataStrippedKeccak256,
+        metadataStrippedSizeBytes: actualBytecode.metadataStrippedSizeBytes,
+        metadataStrippedOpcodesSha256: sha256(
+          actualBytecode.metadataStrippedOpcodes
+        ),
+      };
+      if (
+        !valuesEqual(actual, expected) ||
+        actualBytecode.metadataStrippedOpcodes !== expectedOpcodes
+      ) {
+        throw new Error(
+          `Stage 12a must preserve Stage 11 ${qualifiedName} ${bytecodeKind} exactly`
+        );
+      }
+      bytecodes[bytecodeKind] = {
+        stage11: expected,
+        candidate: actual,
+        equal: true,
+        opcodeInstructionCount: opcodeInstructions(expectedOpcodes).length,
+      };
+    }
+    const runtimeSize = candidateContract.runtimeBytecode.sizeBytes;
+    if (runtimeSize > 24_576) {
+      throw new Error(`${qualifiedName} exceeds the EIP-170 size limit`);
+    }
+    contracts[qualifiedName] = {
+      ...bytecodes,
+      eip170: {
+        limitBytes: 24_576,
+        stage11RuntimeSizeBytes: runtimeSize,
+        candidateRuntimeSizeBytes: runtimeSize,
+        equal: true,
+        candidateWithinLimit: true,
+      },
+    };
+  }
+  const expectedCompiler =
+    checkpoint.evidence.value.productionEquality.compiler;
+  const candidateCompiler = {
+    version: candidate.compiler.version,
+    longVersion: candidate.compiler.longVersion,
+    settingsSha256: sha256(stableJson(candidate.compiler.settings)),
+  };
+  if (!valuesEqual(candidateCompiler, expectedCompiler)) {
+    throw new Error("Stage 12a compiler differs from Stage 11");
+  }
+  return sorted({ compiler: candidateCompiler, contracts });
+}
+
+function stage12aLegacyGasEqualityEvidence(candidate, checkpoint) {
+  const expected = stage12aCheckpointLegacyGasEntries(checkpoint);
+  const actual = candidate.gasSnapshot.entries;
+  if (
+    candidate.gasSnapshot.fuzzSeed !== "0x721" ||
+    !valuesEqual(actual, expected)
+  ) {
+    throw new Error(
+      "Stage 12a must preserve all 15 Stage 11 legacy gas entries"
+    );
+  }
+  return sorted({
+    fuzzSeed: "0x721",
+    inventoryCount: actual.length,
+    stage11EntriesSha256: sha256(stableJson(expected)),
+    candidateEntriesSha256: sha256(stableJson(actual)),
+    equal: true,
+  });
+}
+
+function stage12aKeyFlowGasEqualityEvidence(checkpoint, candidateGas) {
+  const previous = new Map(
+    checkpoint.evidence.value.keyFlowGasEquality.comparisons.map((entry) => [
+      entry.name,
+      entry,
+    ])
+  );
+  const current = new Map();
+  for (const [group, entries] of Object.entries(candidateGas.groups)) {
+    for (const entry of entries) current.set(entry.name, { group, ...entry });
+  }
+  if (!valuesEqual([...previous.keys()].sort(), [...current.keys()].sort())) {
+    throw new Error("Stage 12a must preserve the 12 key-flow gas inventory");
+  }
+  const comparisons = [...previous.keys()].sort().map((name) => {
+    const stage11 = previous.get(name);
+    const candidateEntry = current.get(name);
+    if (
+      !stage11.equal ||
+      stage11.group !== candidateEntry.group ||
+      stage11.candidateGas !== candidateEntry.candidateGas ||
+      stage11.baselineGas !== candidateEntry.baselineGas ||
+      stage11.maximumGas !== candidateEntry.maximumGas ||
+      !candidateEntry.withinLimit
+    ) {
+      throw new Error(`Stage 12a key-flow gas changed: ${name}`);
+    }
+    return {
+      group: candidateEntry.group,
+      name,
+      stage11Gas: stage11.candidateGas,
+      candidateGas: candidateEntry.candidateGas,
+      equal: true,
+      baselineGas: candidateEntry.baselineGas,
+      maximumGas: candidateEntry.maximumGas,
+      withinBaselineLimit: true,
+    };
+  });
+  return sorted({
+    baselinePath: candidateGas.baselinePath,
+    baselineSha256: candidateGas.baselineSha256,
+    baselinePolicy: candidateGas.policy,
+    fuzzSeed: candidateGas.fuzzSeed,
+    comparisons,
+  });
+}
+
+function stage12aEvidence(review, baseline, candidate) {
+  const checkpoint = stage12aCheckpointAnchor();
+  return sorted({
+    schemaVersion: 1,
+    candidate: review.candidate,
+    baselineSha256: review.baselineSha256,
+    mode: review.opcodeEvidence.mode,
+    inheritedStage11Checkpoint: STAGE_12A_CHECKPOINT_BINDING,
+    toolingAndTestMigration: stage12aSourceEvidence(candidate),
+    hardCompatibility: stage12aHardCompatibilityEvidence(
+      baseline,
+      candidate,
+      checkpoint
+    ),
+    productionEquality: stage12aProductionEqualityEvidence(
+      baseline,
+      candidate,
+      checkpoint
+    ),
+    legacyGasEquality: stage12aLegacyGasEqualityEvidence(candidate, checkpoint),
+    keyFlowGasEquality: stage12aKeyFlowGasEqualityEvidence(
+      checkpoint,
+      stage08GasEvidence()
+    ),
+  });
+}
+
 function security01ComparisonBaseline(baseline, candidate) {
   validateSecurity01Inventory(candidate);
   security01SourceEvidence();
@@ -8669,6 +9708,70 @@ function stage11ComparisonBaseline(baseline, candidate) {
   expectedToolchain.forge[2] = candidate.toolchain.forge[2];
   if (!valuesEqual(candidate.toolchain, expectedToolchain)) {
     throw new Error("Stage 11 must preserve the pinned toolchain identity");
+  }
+  comparison.toolchain = expectedToolchain;
+  return comparison;
+}
+
+function stage12aComparisonBaseline(baseline, candidate) {
+  const checkpoint = stage12aCheckpointAnchor();
+  stage12aTestInventory(candidate, checkpoint);
+  stage12aSourceEvidence(candidate);
+  const comparison = deepClone(baseline);
+  const checkpointCompiler =
+    checkpoint.evidence.value.productionEquality.compiler;
+  if (
+    checkpointCompiler.version !== STAGE_08_COMPILER_VERSION ||
+    checkpointCompiler.longVersion !== STAGE_08_COMPILER_LONG_VERSION ||
+    checkpointCompiler.settingsSha256 !==
+      sha256(stableJson(baseline.compiler.settings))
+  ) {
+    throw new Error("Stage 12a inherited an invalid Stage 11 compiler anchor");
+  }
+  comparison.compiler.version = checkpointCompiler.version;
+  comparison.compiler.longVersion = checkpointCompiler.longVersion;
+
+  for (const qualifiedName of STAGE_08_PRODUCTION_CONTRACTS) {
+    for (const bytecodeKind of ["creationBytecode", "runtimeBytecode"]) {
+      const bytecode = stage12aCheckpointBytecode(
+        checkpoint,
+        qualifiedName,
+        bytecodeKind
+      );
+      Object.assign(comparison.contracts[qualifiedName][bytecodeKind], {
+        keccak256: bytecode.rawKeccak256,
+        sizeBytes: bytecode.rawSizeBytes,
+        metadataBytes: bytecode.metadataBytes,
+        metadataStrippedKeccak256: bytecode.metadataStrippedKeccak256,
+        metadataStrippedSizeBytes: bytecode.metadataStrippedSizeBytes,
+        metadataStrippedOpcodes: stage12aCheckpointOpcodes(
+          baseline,
+          qualifiedName,
+          bytecodeKind,
+          checkpoint
+        ),
+      });
+    }
+  }
+  comparison.gasSnapshot.entries =
+    stage12aCheckpointLegacyGasEntries(checkpoint);
+  comparison.projectRevertStrings = security04ProjectRevertStrings(
+    baseline.projectRevertStrings
+  );
+  comparison.tests.hardhat = deepClone(
+    checkpoint.evidence.value.sourceAndTestCutover.tests.activeHardhat
+  );
+  const parity = stage06ParityForgeTests();
+  comparison.tests.forge = {
+    count: STAGE_11_FORGE_COUNT,
+    names: [...parity.forgeNames, ...stage07SafetyForgeTests()].sort(),
+  };
+  comparison.tests.total = 3 + STAGE_11_FORGE_COUNT;
+
+  const expectedToolchain = deepClone(baseline.toolchain);
+  expectedToolchain.forge[2] = candidate.toolchain.forge[2];
+  if (!valuesEqual(candidate.toolchain, expectedToolchain)) {
+    throw new Error("Stage 12a must preserve the pinned toolchain identity");
   }
   comparison.toolchain = expectedToolchain;
   return comparison;
@@ -9982,6 +11085,233 @@ function stage11NegativeProbes(baseline, candidate, review) {
   return probes;
 }
 
+function expectStage12aRejection(name, operation) {
+  try {
+    operation();
+  } catch (_error) {
+    return name;
+  }
+  throw new Error(`Stage 12a negative probe unexpectedly passed: ${name}`);
+}
+
+function stage12aNegativeProbes(baseline, candidate, review) {
+  const probes = [];
+  const reject = (name, operation) => {
+    probes.push(expectStage12aRejection(name, operation));
+  };
+  const rejectCandidate = (name, mutate) => {
+    const drift = deepClone(candidate);
+    mutate(drift);
+    reject(name, () => validateStage12aCandidate(baseline, drift));
+  };
+  const wrapperName = "contracts/Wrapper.sol:Wrapper";
+  const pcoName =
+    "contracts/token/PartialCommonOwnership.sol:PartialCommonOwnership";
+
+  const checkpointCommit = deepClone(review);
+  checkpointCommit.stage11Checkpoint.commit = "0".repeat(40);
+  reject("Stage 11 checkpoint commit drift", () =>
+    reviewPolicy(checkpointCommit)
+  );
+  const checkpointEvidence = deepClone(review);
+  checkpointEvidence.stage11Checkpoint.evidence.sha256 = "0".repeat(64);
+  reject("Stage 11 checkpoint evidence drift", () =>
+    reviewPolicy(checkpointEvidence)
+  );
+  const checkpointReview = deepClone(review);
+  checkpointReview.stage11Checkpoint.review.sha256 = "0".repeat(64);
+  reject("Stage 11 checkpoint review drift", () =>
+    reviewPolicy(checkpointReview)
+  );
+  const migrationReview = deepClone(review);
+  migrationReview.migrationEvidence.dependencyMigration.lockfileSha256 =
+    "0".repeat(64);
+  reject("migration review evidence drift", () =>
+    reviewPolicy(migrationReview)
+  );
+
+  rejectCandidate("Hardhat smoke count drift", (drift) => {
+    drift.tests.hardhat.count += 1;
+  });
+  rejectCandidate("Hardhat smoke identifier drift", (drift) => {
+    drift.tests.hardhat.names[0] += " drift";
+  });
+  rejectCandidate("Forge identifier removal", (drift) => {
+    drift.tests.forge.names.pop();
+    drift.tests.forge.count -= 1;
+    drift.tests.total -= 1;
+  });
+  rejectCandidate("Forge identifier addition", (drift) => {
+    drift.tests.forge.names.push(
+      "test/solidity/fuzz/Unexpected.t.sol:UnexpectedTest:test_unexpected"
+    );
+    drift.tests.forge.names.sort();
+    drift.tests.forge.count += 1;
+    drift.tests.total += 1;
+  });
+  rejectCandidate("combined test total drift", (drift) => {
+    drift.tests.total += 1;
+  });
+  rejectCandidate("compiler version drift", (drift) => {
+    drift.compiler.version = "0.8.35";
+  });
+  rejectCandidate("compiler settings drift", (drift) => {
+    drift.compiler.settings.optimizer.enabled = true;
+  });
+  rejectCandidate("ABI drift", (drift) => {
+    drift.contracts[wrapperName].abi.pop();
+  });
+  rejectCandidate("function selector drift", (drift) => {
+    drift.contracts[wrapperName].functions[0].selector = "0x00000000";
+  });
+  rejectCandidate("event drift", (drift) => {
+    drift.contracts[wrapperName].events.pop();
+  });
+  rejectCandidate("custom error drift", (drift) => {
+    drift.contracts[wrapperName].errors.pop();
+  });
+  rejectCandidate("storage layout drift", (drift) => {
+    drift.contracts[pcoName].storageLayout.storage[0].slot = "999";
+  });
+  rejectCandidate("interface drift", (drift) => {
+    drift.interfaces[Object.keys(drift.interfaces)[0]].interfaceId =
+      "0x00000000";
+  });
+  rejectCandidate("enum ordinal drift", (drift) => {
+    drift.enums[0].members[0].ordinal = 999;
+  });
+  rejectCandidate("ERC165 drift", (drift) => {
+    drift.erc165.probes.Wrapper[0].supported =
+      !drift.erc165.probes.Wrapper[0].supported;
+  });
+  rejectCandidate("project revert drift", (drift) => {
+    drift.projectRevertStrings[0].value += " drift";
+  });
+  rejectCandidate("raw bytecode drift", (drift) => {
+    drift.contracts[wrapperName].runtimeBytecode.keccak256 = `0x${"00".repeat(
+      32
+    )}`;
+  });
+  rejectCandidate("metadata-stripped opcode drift", (drift) => {
+    drift.contracts[wrapperName].runtimeBytecode.metadataStrippedOpcodes +=
+      " STOP";
+  });
+  rejectCandidate("runtime size drift", (drift) => {
+    drift.contracts[pcoName].runtimeBytecode.sizeBytes += 1;
+  });
+  rejectCandidate("legacy gas drift", (drift) => {
+    drift.gasSnapshot.entries[0] += " drift";
+  });
+
+  const packageJson = JSON.parse(
+    fs.readFileSync(path.join(ROOT, "package.json"), "utf8")
+  );
+  const packageProbe = (name, mutate) => {
+    const drift = deepClone(packageJson);
+    mutate(drift);
+    reject(name, () => validateStage12aPackageManifest(drift));
+  };
+  packageProbe("ethers version drift", (drift) => {
+    drift.devDependencies.ethers = "6.16.0";
+  });
+  packageProbe("Foundation plugin version drift", (drift) => {
+    drift.devDependencies["@nomicfoundation/hardhat-ethers"] = "3.1.2";
+  });
+  packageProbe("Hardhat version drift", (drift) => {
+    drift.devDependencies.hardhat = "2.28.5";
+  });
+  packageProbe("dormant legacy dependency removal", (drift) => {
+    delete drift.devDependencies["@nomiclabs/hardhat-waffle"];
+  });
+  packageProbe("runtime dependency drift", (drift) => {
+    drift.dependencies["@openzeppelin/contracts"] = "5.6.0";
+  });
+  packageProbe("TypeChain runtime invocation", (drift) => {
+    drift.scripts.typechain = "hardhat typechain";
+  });
+  const lock = fs.readFileSync(path.join(ROOT, "pnpm-lock.yaml"), "utf8");
+  reject("ethers lock integrity drift", () =>
+    validateStage12aLockDependency(
+      lock.replace(STAGE_12A_ETHERS_INTEGRITY, "sha512-drift"),
+      "ethers",
+      STAGE_12A_ETHERS_VERSION,
+      STAGE_12A_ETHERS_INTEGRITY
+    )
+  );
+  reject("Foundation plugin lock integrity drift", () =>
+    validateStage12aLockDependency(
+      lock.replace(STAGE_12A_HARDHAT_ETHERS_INTEGRITY, "sha512-drift"),
+      "@nomicfoundation/hardhat-ethers",
+      STAGE_12A_HARDHAT_ETHERS_VERSION,
+      STAGE_12A_HARDHAT_ETHERS_INTEGRITY
+    )
+  );
+
+  const checkpoint = stage12aCheckpointAnchor();
+  const productionCheckpointDrift = deepClone(checkpoint);
+  productionCheckpointDrift.evidence.value.sourceAndTestCutover.productionSources[
+    STAGE_10_PRODUCTION_SOURCES[0]
+  ].sha256 = "0".repeat(64);
+  reject("production source equality drift", () =>
+    stage12aProductionSourceEquality(productionCheckpointDrift)
+  );
+  const compilerCheckpointDrift = deepClone(checkpoint);
+  compilerCheckpointDrift.evidence.value.sourceAndTestCutover.compilerSources.candidateClosureSha256 =
+    "0".repeat(64);
+  reject("compiler source closure drift", () =>
+    stage12aCompilerSourceEquality(compilerCheckpointDrift)
+  );
+  const keyFlowDrift = deepClone(stage08GasEvidence());
+  const gasGroup = Object.keys(keyFlowDrift.groups)[0];
+  keyFlowDrift.groups[gasGroup][0].candidateGas += 1;
+  reject("key-flow gas drift", () =>
+    stage12aKeyFlowGasEqualityEvidence(checkpoint, keyFlowDrift)
+  );
+  const boundFiles = stage12aBoundFileEvidence();
+  const boundFileDrift = deepClone(boundFiles);
+  boundFileDrift[Object.keys(boundFileDrift)[0]] = "0".repeat(64);
+  reject("bound file digest drift", () =>
+    validateExactFileDigests(
+      boundFileDrift,
+      STAGE_12A_BOUND_FILES,
+      "stage12aFiles"
+    )
+  );
+  reject("unexpected repository path", () =>
+    validateStage12aChangedPaths([
+      ...STAGE_12A_FINAL_CHANGED_PATHS,
+      "unexpected-stage-12a-file",
+    ])
+  );
+
+  const unauthorizedReview = deepClone(review);
+  const unauthorizedDifference = {
+    path: "$.tests.hardhat.count",
+    baselineValue: 3,
+    candidateValue: 4,
+    reason: "probe",
+  };
+  unauthorizedReview.allowedDifferences.push(unauthorizedDifference);
+  reject("compatibility difference waiver", () =>
+    validateReviewedDifferences(
+      unauthorizedReview,
+      fs.readFileSync(BASELINE_PATH),
+      [unauthorizedDifference]
+    )
+  );
+
+  const evidencePath = opcodeEvidencePath(review);
+  const checkedInEvidence = JSON.parse(fs.readFileSync(evidencePath, "utf8"));
+  const staleEvidence = deepClone(checkedInEvidence);
+  staleEvidence.toolingAndTestMigration.dependencyMigration.transition.ethers.candidate =
+    "6.16.0";
+  reject("stale Stage 12a evidence", () =>
+    validateExactOpcodeEvidence(staleEvidence, checkedInEvidence)
+  );
+
+  return probes;
+}
+
 function reviewedOpcodeEvidence(review, baseline, candidate) {
   const configuration = review.opcodeEvidence;
   if (!configuration) return null;
@@ -9996,6 +11326,7 @@ function reviewedOpcodeEvidence(review, baseline, candidate) {
       "security-04-security-03-relative-wrapper-only",
       "stage-10-security-04-relative-full-diff",
       "stage-11-stage-10-production-equality",
+      "stage-12a-stage-11-production-equality",
     ].includes(configuration.mode)
   ) {
     throw new Error(`Unsupported opcode evidence mode: ${configuration.mode}`);
@@ -10026,6 +11357,9 @@ function reviewedOpcodeEvidence(review, baseline, candidate) {
   }
   if (configuration.mode === "stage-11-stage-10-production-equality") {
     return stage11Evidence(review, baseline, candidate);
+  }
+  if (configuration.mode === "stage-12a-stage-11-production-equality") {
+    return stage12aEvidence(review, baseline, candidate);
   }
 
   const contracts = {};
@@ -10243,6 +11577,7 @@ function expectedProjectRevertStrings(command, protectedRevertStrings) {
   if (command === "write-security-04-review") return security04Candidate;
   if (command === "write-stage-10-review") return security04Candidate;
   if (command === "write-stage-11-review") return security04Candidate;
+  if (command === "write-stage-12a-review") return security04Candidate;
   if (command === "diff") {
     return {
       baseline: protectedRevertStrings,
@@ -10262,6 +11597,7 @@ function expectedProjectRevertStrings(command, protectedRevertStrings) {
       "security-04-negative-probes",
       "stage-10-negative-probes",
       "stage-11-negative-probes",
+      "stage-12a-negative-probes",
     ].includes(command) &&
     fs.existsSync(REVIEW_PATH)
   ) {
@@ -10272,6 +11608,7 @@ function expectedProjectRevertStrings(command, protectedRevertStrings) {
     if (review.policy === SECURITY_04_POLICY) return security04Candidate;
     if (review.policy === STAGE_10_POLICY) return security04Candidate;
     if (review.policy === STAGE_11_POLICY) return security04Candidate;
+    if (review.policy === STAGE_12A_POLICY) return security04Candidate;
   }
   return protectedRevertStrings;
 }
@@ -10291,6 +11628,7 @@ async function main() {
       "security-04-negative-probes",
       "stage-10-negative-probes",
       "stage-11-negative-probes",
+      "stage-12a-negative-probes",
       "write-stage-08-review",
       "write-stage-09-review",
       "write-security-01-review",
@@ -10299,11 +11637,12 @@ async function main() {
       "write-security-04-review",
       "write-stage-10-review",
       "write-stage-11-review",
+      "write-stage-12a-review",
       "write-evidence",
     ].includes(command)
   ) {
     console.error(
-      "Usage: node scripts/compatibility.js <capture|check|diff|revert-strings|stage-09-negative-probes|security-01-negative-probes|security-02-negative-probes|security-03-negative-probes|security-04-negative-probes|stage-10-negative-probes|stage-11-negative-probes|write-stage-08-review|write-stage-09-review|write-security-01-review|write-security-02-review|write-security-03-review|write-security-04-review|write-stage-10-review|write-stage-11-review|write-evidence>"
+      "Usage: node scripts/compatibility.js <capture|check|diff|revert-strings|stage-09-negative-probes|security-01-negative-probes|security-02-negative-probes|security-03-negative-probes|security-04-negative-probes|stage-10-negative-probes|stage-11-negative-probes|stage-12a-negative-probes|write-stage-08-review|write-stage-09-review|write-security-01-review|write-security-02-review|write-security-03-review|write-security-04-review|write-stage-10-review|write-stage-11-review|write-stage-12a-review|write-evidence>"
     );
     process.exitCode = 2;
     return;
@@ -10388,6 +11727,7 @@ async function main() {
     "security-04-negative-probes",
     "stage-10-negative-probes",
     "stage-11-negative-probes",
+    "stage-12a-negative-probes",
   ].includes(command);
   const security01ReviewActive =
     command === "write-security-01-review" ||
@@ -10407,7 +11747,12 @@ async function main() {
   const stage11ReviewActive =
     command === "write-stage-11-review" ||
     (inheritedReviewCommand && existingReview?.policy === STAGE_11_POLICY);
-  const comparisonBaseline = stage11ReviewActive
+  const stage12aReviewActive =
+    command === "write-stage-12a-review" ||
+    (inheritedReviewCommand && existingReview?.policy === STAGE_12A_POLICY);
+  const comparisonBaseline = stage12aReviewActive
+    ? stage12aComparisonBaseline(baseline, manifest)
+    : stage11ReviewActive
     ? stage11ComparisonBaseline(baseline, manifest)
     : stage10ReviewActive
     ? stage10ComparisonBaseline(baseline, manifest)
@@ -10567,6 +11912,23 @@ async function main() {
     );
     return;
   }
+  if (command === "write-stage-12a-review") {
+    const review = stage12aReview(baselineBytes, differences, manifest);
+    validateReviewedDifferences(review, baselineBytes, differences);
+    const policy = reviewPolicy(review);
+    policy.validateCandidate(baseline, manifest);
+    validateSafetyEvidence(review);
+    fs.writeFileSync(REVIEW_PATH, stableJson(review));
+    console.log(
+      `Wrote ${
+        differences.length
+      } exact Stage 12a reviewed differences to ${path.relative(
+        ROOT,
+        REVIEW_PATH
+      )}`
+    );
+    return;
+  }
   if (command === "stage-09-negative-probes") {
     const probes = stage09NegativeProbes(baseline, manifest);
     console.log(`Stage 9 negative probes passed: ${probes.join("; ")}`);
@@ -10662,6 +12024,22 @@ async function main() {
     validateOpcodeEvidence(review, baseline, manifest);
     const probes = stage11NegativeProbes(baseline, manifest, review);
     console.log(`Stage 11 negative probes passed: ${probes.join("; ")}`);
+    return;
+  }
+  if (command === "stage-12a-negative-probes") {
+    const review = readReviewedDifferences();
+    if (!review || review.policy !== STAGE_12A_POLICY) {
+      throw new Error(
+        "Stage 12a negative probes require the exact Stage 12a review"
+      );
+    }
+    validateReviewedDifferences(review, baselineBytes, differences);
+    const policy = reviewPolicy(review);
+    policy.validateCandidate(baseline, manifest);
+    validateSafetyEvidence(review);
+    validateOpcodeEvidence(review, baseline, manifest);
+    const probes = stage12aNegativeProbes(baseline, manifest, review);
+    console.log(`Stage 12a negative probes passed: ${probes.join("; ")}`);
     return;
   }
   const review = existingReview;

--- a/tests/Interoperability.smoke.ts
+++ b/tests/Interoperability.smoke.ts
@@ -1,27 +1,33 @@
 import { expect } from "chai";
 import { ethers, network } from "hardhat";
 
-import type { BigNumber, Contract, ContractReceipt } from "ethers";
+import type {
+  Contract,
+  ContractTransactionReceipt,
+  ContractTransactionResponse,
+  LogDescription,
+} from "ethers";
 
 type EventSource = {
   label: string;
   contract: Contract;
+  address: string;
 };
 
 type DecodedEvent = {
   source: string;
   name: string;
-  args: any;
+  args: LogDescription["args"];
 };
 
-const ZERO_ADDRESS = ethers.constants.AddressZero;
-const ZERO = ethers.constants.Zero;
-const ONE_ETHER = ethers.utils.parseEther("1");
-const TWO_ETHER = ethers.utils.parseEther("2");
-const THREE_ETHER = ethers.utils.parseEther("3");
+const ZERO_ADDRESS = ethers.ZeroAddress;
+const ZERO = BigInt(0);
+const ONE_ETHER = ethers.parseEther("1");
+const TWO_ETHER = ethers.parseEther("2");
+const THREE_ETHER = ethers.parseEther("3");
 const NINETY_DAYS = 90 * 24 * 60 * 60;
 const TEN_YEARS = 3650 * 24 * 60 * 60;
-const TAX_DENOMINATOR = ethers.BigNumber.from("1000000000000");
+const TAX_DENOMINATOR = BigInt("1000000000000");
 
 const NETWORK_START = 2_000_000_000;
 const ACQUISITION_TIME = 2_000_010_000;
@@ -32,49 +38,92 @@ const WRAP_TIME = 2_000_020_000;
 const TAKEOVER_TIME = WRAP_TIME + 100;
 const UNWRAP_TIME = TAKEOVER_TIME + 1;
 
-const TOKEN_ID = 1;
-const TAX_RATE_FIVE_PERCENT = ethers.BigNumber.from("50000000000");
-const TAX_RATE_MINIMUM = ethers.BigNumber.from(1);
+const TOKEN_ID = BigInt(1);
+const TAX_RATE_FIVE_PERCENT = BigInt("50000000000");
+const TAX_RATE_MINIMUM = BigInt(1);
 
 function calculateTax(
-  valuation: BigNumber,
+  valuation: bigint,
   elapsed: number,
   frequency: number,
-  taxRate: BigNumber
-): BigNumber {
-  return valuation
-    .mul(elapsed)
-    .div(frequency)
-    .mul(taxRate)
-    .div(TAX_DENOMINATOR);
+  taxRate: bigint
+): bigint {
+  return (
+    (((valuation * BigInt(elapsed)) / BigInt(frequency)) * taxRate) /
+    TAX_DENOMINATOR
+  );
+}
+
+async function requiredReceipt(
+  transaction: ContractTransactionResponse
+): Promise<ContractTransactionReceipt> {
+  const receipt = await transaction.wait();
+  if (receipt === null) throw new Error("Transaction was not mined");
+  return receipt;
+}
+
+async function eventSource(
+  label: string,
+  contract: Contract
+): Promise<EventSource> {
+  return {
+    label,
+    contract,
+    address: (await contract.getAddress()).toLowerCase(),
+  };
 }
 
 function decodeEvents(
-  receipt: ContractReceipt,
+  receipt: ContractTransactionReceipt,
   sources: EventSource[]
 ): DecodedEvent[] {
   const events: DecodedEvent[] = [];
 
   for (const log of receipt.logs) {
     const source = sources.find(
-      ({ contract }) =>
-        contract.address.toLowerCase() === log.address.toLowerCase()
+      ({ address }) => address === log.address.toLowerCase()
     );
     if (!source) continue;
 
-    try {
-      const parsed = source.contract.interface.parseLog(log);
-      events.push({
-        source: source.label,
-        name: parsed.name,
-        args: parsed.args,
-      });
-    } catch {
-      // Ignore logs that are not described by the source contract's interface.
-    }
+    const parsed = source.contract.interface.parseLog({
+      topics: log.topics,
+      data: log.data,
+    });
+    if (parsed === null) continue;
+
+    events.push({
+      source: source.label,
+      name: parsed.name,
+      args: parsed.args,
+    });
   }
 
   return events;
+}
+
+async function expectRevertReason(
+  action: Promise<unknown>,
+  expectedReason: string
+): Promise<void> {
+  let caught: unknown;
+  try {
+    await action;
+  } catch (error) {
+    caught = error;
+  }
+
+  if (caught === undefined) {
+    expect.fail(`Expected transaction to revert with: ${expectedReason}`);
+  }
+  if (ethers.isError(caught, "CALL_EXCEPTION") && caught.reason !== null) {
+    expect(caught.reason).to.equal(expectedReason);
+    return;
+  }
+  if (caught instanceof Error) {
+    expect(caught.message).to.include(expectedReason);
+    return;
+  }
+  expect.fail(`Unexpected rejection value: ${String(caught)}`);
 }
 
 function eventNames(events: DecodedEvent[]): string[] {
@@ -98,27 +147,29 @@ describe("Hardhat interoperability smokes", function () {
 
   it("deploys and reads deterministic PCO configuration", async function () {
     const [, beneficiary] = await ethers.getSigners();
+    const beneficiaryAddress = await beneficiary.getAddress();
     const pcoFactory = await ethers.getContractFactory("TestPCOToken");
-    const pco = await pcoFactory.deploy(beneficiary.address);
-    await pco.deployed();
+    const pco = await pcoFactory.deploy(beneficiaryAddress);
+    await pco.waitForDeployment();
+    const pcoAddress = await pco.getAddress();
 
     expect(await pco.supportsInterface("0x01ffc9a7")).to.equal(true);
     expect(await pco.supportsInterface("0x80ac58cd")).to.equal(true);
     expect(await pco.supportsInterface("0x5b5e139f")).to.equal(false);
 
     const expectedRates = [
-      ethers.BigNumber.from("50000000000"),
-      ethers.BigNumber.from("1000000000000"),
-      ethers.BigNumber.from("1000000000000"),
+      BigInt("50000000000"),
+      BigInt("1000000000000"),
+      BigInt("1000000000000"),
     ];
-    const expectedFrequencies = [90, 30, 365].map(
-      (days) => days * 24 * 60 * 60
+    const expectedFrequencies = [90, 30, 365].map((days) =>
+      BigInt(days * 24 * 60 * 60)
     );
 
     for (let index = 0; index < 3; index++) {
-      const tokenId = index + 1;
-      expect(await pco.ownerOf(tokenId)).to.equal(pco.address);
-      expect(await pco.beneficiaryOf(tokenId)).to.equal(beneficiary.address);
+      const tokenId = BigInt(index + 1);
+      expect(await pco.ownerOf(tokenId)).to.equal(pcoAddress);
+      expect(await pco.beneficiaryOf(tokenId)).to.equal(beneficiaryAddress);
       expect(await pco.taxRateOf(tokenId)).to.equal(expectedRates[index]);
       expect(await pco.collectionFrequencyOf(tokenId)).to.equal(
         expectedFrequencies[index]
@@ -132,20 +183,26 @@ describe("Hardhat interoperability smokes", function () {
 
   it("acquires, collects tax, and exits with ordered events and conserved balances", async function () {
     const [collector, beneficiary, alice] = await ethers.getSigners();
+    const beneficiaryAddress = await beneficiary.getAddress();
+    const aliceAddress = await alice.getAddress();
     const pcoFactory = await ethers.getContractFactory("TestPCOToken");
-    const pco = await pcoFactory.deploy(beneficiary.address);
-    await pco.deployed();
+    const pco = await pcoFactory.deploy(beneficiaryAddress);
+    await pco.waitForDeployment();
+    const pcoAddress = await pco.getAddress();
 
-    const valuation = ethers.utils.parseEther("9");
+    const valuation = ethers.parseEther("9");
     const initialDeposit = TWO_ETHER;
 
     await setNextTimestamp(ACQUISITION_TIME);
-    const acquisition = await pco
-      .connect(alice)
-      .takeoverLease(TOKEN_ID, valuation, ZERO, { value: initialDeposit });
-    const acquisitionReceipt = await acquisition.wait();
+    const acquisition = await (pco.connect(alice) as Contract).takeoverLease(
+      TOKEN_ID,
+      valuation,
+      ZERO,
+      { value: initialDeposit }
+    );
+    const acquisitionReceipt = await requiredReceipt(acquisition);
     const acquisitionEvents = decodeEvents(acquisitionReceipt, [
-      { label: "pco", contract: pco },
+      await eventSource("pco", pco),
     ]);
 
     expect(eventNames(acquisitionEvents)).to.deep.equal([
@@ -156,18 +213,20 @@ describe("Hardhat interoperability smokes", function () {
     ]);
     expect(acquisitionEvents[0].args.tokenId).to.equal(TOKEN_ID);
     expect(acquisitionEvents[0].args.newValuation).to.equal(valuation);
-    expect(acquisitionEvents[1].args.owner).to.equal(pco.address);
+    expect(acquisitionEvents[1].args.owner).to.equal(pcoAddress);
     expect(acquisitionEvents[1].args.approved).to.equal(ZERO_ADDRESS);
-    expect(acquisitionEvents[2].args.from).to.equal(pco.address);
-    expect(acquisitionEvents[2].args.to).to.equal(alice.address);
-    expect(acquisitionEvents[3].args.owner).to.equal(alice.address);
+    expect(acquisitionEvents[2].args.from).to.equal(pcoAddress);
+    expect(acquisitionEvents[2].args.to).to.equal(aliceAddress);
+    expect(acquisitionEvents[3].args.owner).to.equal(aliceAddress);
     expect(acquisitionEvents[3].args.newValuation).to.equal(valuation);
 
-    expect(await pco.ownerOf(TOKEN_ID)).to.equal(alice.address);
+    expect(await pco.ownerOf(TOKEN_ID)).to.equal(aliceAddress);
     expect(await pco.valuationOf(TOKEN_ID)).to.equal(valuation);
     expect(await pco.depositOf(TOKEN_ID)).to.equal(initialDeposit);
-    expect(await pco.lastCollectionTimeOf(TOKEN_ID)).to.equal(ACQUISITION_TIME);
-    expect(await ethers.provider.getBalance(pco.address)).to.equal(
+    expect(await pco.lastCollectionTimeOf(TOKEN_ID)).to.equal(
+      BigInt(ACQUISITION_TIME)
+    );
+    expect(await ethers.provider.getBalance(pcoAddress)).to.equal(
       initialDeposit
     );
 
@@ -177,13 +236,17 @@ describe("Hardhat interoperability smokes", function () {
       NINETY_DAYS,
       TAX_RATE_FIVE_PERCENT
     );
-    const beneficiaryBeforeCollection = await beneficiary.getBalance();
+    const beneficiaryBeforeCollection = await ethers.provider.getBalance(
+      beneficiaryAddress
+    );
 
     await setNextTimestamp(COLLECTION_TIME);
-    const collection = await pco.connect(collector).collectTax(TOKEN_ID);
-    const collectionReceipt = await collection.wait();
+    const collection = await (pco.connect(collector) as Contract).collectTax(
+      TOKEN_ID
+    );
+    const collectionReceipt = await requiredReceipt(collection);
     const collectionEvents = decodeEvents(collectionReceipt, [
-      { label: "pco", contract: pco },
+      await eventSource("pco", pco),
     ]);
 
     expect(eventNames(collectionEvents)).to.deep.equal([
@@ -192,23 +255,24 @@ describe("Hardhat interoperability smokes", function () {
     ]);
     expect(collectionEvents[0].args.tokenId).to.equal(TOKEN_ID);
     expect(collectionEvents[0].args.collected).to.equal(firstTax);
-    expect(collectionEvents[1].args.trigger).to.equal(3);
-    expect(collectionEvents[1].args.recipient).to.equal(beneficiary.address);
+    expect(collectionEvents[1].args.trigger).to.equal(BigInt(3));
+    expect(collectionEvents[1].args.recipient).to.equal(beneficiaryAddress);
     expect(collectionEvents[1].args.amount).to.equal(firstTax);
 
     expect(
-      (await beneficiary.getBalance()).sub(beneficiaryBeforeCollection)
+      (await ethers.provider.getBalance(beneficiaryAddress)) -
+        beneficiaryBeforeCollection
     ).to.equal(firstTax);
-    expect(await pco.depositOf(TOKEN_ID)).to.equal(
-      initialDeposit.sub(firstTax)
-    );
+    expect(await pco.depositOf(TOKEN_ID)).to.equal(initialDeposit - firstTax);
     expect(await pco.taxationCollected(TOKEN_ID)).to.equal(firstTax);
     expect(await pco.taxCollectedSinceLastTransferOf(TOKEN_ID)).to.equal(
       firstTax
     );
-    expect(await pco.lastCollectionTimeOf(TOKEN_ID)).to.equal(COLLECTION_TIME);
-    expect(await ethers.provider.getBalance(pco.address)).to.equal(
-      initialDeposit.sub(firstTax)
+    expect(await pco.lastCollectionTimeOf(TOKEN_ID)).to.equal(
+      BigInt(COLLECTION_TIME)
+    );
+    expect(await ethers.provider.getBalance(pcoAddress)).to.equal(
+      initialDeposit - firstTax
     );
 
     const exitTax = calculateTax(
@@ -217,15 +281,17 @@ describe("Hardhat interoperability smokes", function () {
       NINETY_DAYS,
       TAX_RATE_FIVE_PERCENT
     );
-    const returnedDeposit = initialDeposit.sub(firstTax).sub(exitTax);
-    const aliceBeforeExit = await alice.getBalance();
-    const beneficiaryBeforeExit = await beneficiary.getBalance();
+    const returnedDeposit = initialDeposit - firstTax - exitTax;
+    const aliceBeforeExit = await ethers.provider.getBalance(aliceAddress);
+    const beneficiaryBeforeExit = await ethers.provider.getBalance(
+      beneficiaryAddress
+    );
 
     await setNextTimestamp(EXIT_TIME);
-    const exit = await pco.connect(alice).exit(TOKEN_ID);
-    const exitReceipt = await exit.wait();
+    const exit = await (pco.connect(alice) as Contract).exit(TOKEN_ID);
+    const exitReceipt = await requiredReceipt(exit);
     const exitEvents = decodeEvents(exitReceipt, [
-      { label: "pco", contract: pco },
+      await eventSource("pco", pco),
     ]);
 
     expect(eventNames(exitEvents)).to.deep.equal([
@@ -238,90 +304,94 @@ describe("Hardhat interoperability smokes", function () {
       "pco.LogForeclosure",
     ]);
     expect(exitEvents[0].args.collected).to.equal(exitTax);
-    expect(exitEvents[1].args.trigger).to.equal(3);
-    expect(exitEvents[1].args.recipient).to.equal(beneficiary.address);
+    expect(exitEvents[1].args.trigger).to.equal(BigInt(3));
+    expect(exitEvents[1].args.recipient).to.equal(beneficiaryAddress);
     expect(exitEvents[1].args.amount).to.equal(exitTax);
-    expect(exitEvents[2].args.trigger).to.equal(1);
-    expect(exitEvents[2].args.recipient).to.equal(alice.address);
+    expect(exitEvents[2].args.trigger).to.equal(BigInt(1));
+    expect(exitEvents[2].args.recipient).to.equal(aliceAddress);
     expect(exitEvents[2].args.amount).to.equal(returnedDeposit);
     expect(exitEvents[3].args.newValuation).to.equal(ZERO);
-    expect(exitEvents[4].args.owner).to.equal(alice.address);
+    expect(exitEvents[4].args.owner).to.equal(aliceAddress);
     expect(exitEvents[4].args.approved).to.equal(ZERO_ADDRESS);
-    expect(exitEvents[5].args.from).to.equal(alice.address);
-    expect(exitEvents[5].args.to).to.equal(pco.address);
-    expect(exitEvents[6].args.prevOwner).to.equal(alice.address);
+    expect(exitEvents[5].args.from).to.equal(aliceAddress);
+    expect(exitEvents[5].args.to).to.equal(pcoAddress);
+    expect(exitEvents[6].args.prevOwner).to.equal(aliceAddress);
 
-    const exitGas = exitReceipt.gasUsed.mul(exitReceipt.effectiveGasPrice);
-    expect(await alice.getBalance()).to.equal(
-      aliceBeforeExit.add(returnedDeposit).sub(exitGas)
+    const exitGas = exitReceipt.gasUsed * exitReceipt.gasPrice;
+    expect(await ethers.provider.getBalance(aliceAddress)).to.equal(
+      aliceBeforeExit + returnedDeposit - exitGas
     );
     expect(
-      (await beneficiary.getBalance()).sub(beneficiaryBeforeExit)
+      (await ethers.provider.getBalance(beneficiaryAddress)) -
+        beneficiaryBeforeExit
     ).to.equal(exitTax);
-    expect(await ethers.provider.getBalance(pco.address)).to.equal(ZERO);
-    expect(await pco.ownerOf(TOKEN_ID)).to.equal(pco.address);
+    expect(await ethers.provider.getBalance(pcoAddress)).to.equal(ZERO);
+    expect(await pco.ownerOf(TOKEN_ID)).to.equal(pcoAddress);
     expect(await pco.valuationOf(TOKEN_ID)).to.equal(ZERO);
     expect(await pco.depositOf(TOKEN_ID)).to.equal(ZERO);
-    expect(await pco.taxationCollected(TOKEN_ID)).to.equal(
-      firstTax.add(exitTax)
-    );
+    expect(await pco.taxationCollected(TOKEN_ID)).to.equal(firstTax + exitTax);
     expect(await pco.taxCollectedSinceLastTransferOf(TOKEN_ID)).to.equal(ZERO);
-    expect(await pco.lastCollectionTimeOf(TOKEN_ID)).to.equal(EXIT_TIME);
+    expect(await pco.lastCollectionTimeOf(TOKEN_ID)).to.equal(
+      BigInt(EXIT_TIME)
+    );
     expect(await pco.foreclosed(TOKEN_ID)).to.equal(true);
   });
 
   it("approves, wraps, takes over, and unwraps with custody and metadata cleanup", async function () {
     const [originator, , buyer] = await ethers.getSigners();
+    const originatorAddress = await originator.getAddress();
+    const buyerAddress = await buyer.getAddress();
     const nftFactory = await ethers.getContractFactory("TestNFT");
     const nft = await nftFactory.connect(originator).deploy();
-    await nft.deployed();
+    await nft.waitForDeployment();
+    const nftAddress = await nft.getAddress();
     const wrapperFactory = await ethers.getContractFactory("TestWrapper");
     const wrapper = await wrapperFactory.connect(originator).deploy();
-    await wrapper.deployed();
+    await wrapper.waitForDeployment();
+    const wrapperAddress = await wrapper.getAddress();
 
     const initialValuation = ONE_ETHER;
     const buyerValuation = TWO_ETHER;
     const initialDeposit = THREE_ETHER;
-    const wrappedId = await wrapper.wrappedTokenId(nft.address, TOKEN_ID);
-    const independentlyDerivedId = ethers.BigNumber.from(
-      ethers.utils.keccak256(
-        ethers.utils.defaultAbiCoder.encode(
+    const wrappedId = await wrapper.wrappedTokenId(nftAddress, TOKEN_ID);
+    const independentlyDerivedId = BigInt(
+      ethers.keccak256(
+        ethers.AbiCoder.defaultAbiCoder().encode(
           ["address", "uint256"],
-          [nft.address, TOKEN_ID]
+          [nftAddress, TOKEN_ID]
         )
       )
     );
     expect(wrappedId).to.equal(independentlyDerivedId);
 
     await setNextTimestamp(APPROVAL_TIME);
-    const approval = await nft
-      .connect(originator)
-      .approve(wrapper.address, TOKEN_ID);
-    const approvalReceipt = await approval.wait();
+    const approval = await (nft.connect(originator) as Contract).approve(
+      wrapperAddress,
+      TOKEN_ID
+    );
+    const approvalReceipt = await requiredReceipt(approval);
     const approvalEvents = decodeEvents(approvalReceipt, [
-      { label: "nft", contract: nft },
+      await eventSource("nft", nft),
     ]);
     expect(eventNames(approvalEvents)).to.deep.equal(["nft.Approval"]);
-    expect(approvalEvents[0].args.owner).to.equal(originator.address);
-    expect(approvalEvents[0].args.approved).to.equal(wrapper.address);
+    expect(approvalEvents[0].args.owner).to.equal(originatorAddress);
+    expect(approvalEvents[0].args.approved).to.equal(wrapperAddress);
     expect(approvalEvents[0].args.tokenId).to.equal(TOKEN_ID);
 
     await setNextTimestamp(WRAP_TIME);
-    const wrap = await wrapper
-      .connect(originator)
-      .wrap(
-        nft.address,
-        TOKEN_ID,
-        initialValuation,
-        buyer.address,
-        TAX_RATE_MINIMUM,
-        3650,
-        { value: initialDeposit }
-      );
-    const wrapReceipt = await wrap.wait();
+    const wrap = await (wrapper.connect(originator) as Contract).wrap(
+      nftAddress,
+      TOKEN_ID,
+      initialValuation,
+      buyerAddress,
+      TAX_RATE_MINIMUM,
+      3650,
+      { value: initialDeposit }
+    );
+    const wrapReceipt = await requiredReceipt(wrap);
     const wrapEvents = decodeEvents(wrapReceipt, [
-      { label: "nft", contract: nft },
-      { label: "wrapper", contract: wrapper },
+      await eventSource("nft", nft),
+      await eventSource("wrapper", wrapper),
     ]);
 
     expect(eventNames(wrapEvents)).to.deep.equal([
@@ -331,27 +401,29 @@ describe("Hardhat interoperability smokes", function () {
       "wrapper.LogBeneficiaryUpdated",
       "wrapper.LogTokenWrapped",
     ]);
-    expect(wrapEvents[0].args.from).to.equal(originator.address);
-    expect(wrapEvents[0].args.to).to.equal(wrapper.address);
+    expect(wrapEvents[0].args.from).to.equal(originatorAddress);
+    expect(wrapEvents[0].args.to).to.equal(wrapperAddress);
     expect(wrapEvents[1].args.from).to.equal(ZERO_ADDRESS);
-    expect(wrapEvents[1].args.to).to.equal(originator.address);
+    expect(wrapEvents[1].args.to).to.equal(originatorAddress);
     expect(wrapEvents[2].args.newValuation).to.equal(initialValuation);
-    expect(wrapEvents[3].args.newBeneficiary).to.equal(buyer.address);
-    expect(wrapEvents[4].args.contractAddress).to.equal(nft.address);
+    expect(wrapEvents[3].args.newBeneficiary).to.equal(buyerAddress);
+    expect(wrapEvents[4].args.contractAddress).to.equal(nftAddress);
     expect(wrapEvents[4].args.tokenId).to.equal(TOKEN_ID);
     expect(wrapEvents[4].args.wrappedTokenId).to.equal(wrappedId);
 
-    expect(await nft.ownerOf(TOKEN_ID)).to.equal(wrapper.address);
+    expect(await nft.ownerOf(TOKEN_ID)).to.equal(wrapperAddress);
     expect(await nft.getApproved(TOKEN_ID)).to.equal(ZERO_ADDRESS);
-    expect(await wrapper.ownerOf(wrappedId)).to.equal(originator.address);
+    expect(await wrapper.ownerOf(wrappedId)).to.equal(originatorAddress);
     expect(await wrapper.tokenURI(wrappedId)).to.equal("721.dev/1");
     expect(await wrapper.valuationOf(wrappedId)).to.equal(initialValuation);
     expect(await wrapper.depositOf(wrappedId)).to.equal(initialDeposit);
-    expect(await wrapper.beneficiaryOf(wrappedId)).to.equal(buyer.address);
+    expect(await wrapper.beneficiaryOf(wrappedId)).to.equal(buyerAddress);
     expect(await wrapper.taxRateOf(wrappedId)).to.equal(TAX_RATE_MINIMUM);
-    expect(await wrapper.collectionFrequencyOf(wrappedId)).to.equal(TEN_YEARS);
+    expect(await wrapper.collectionFrequencyOf(wrappedId)).to.equal(
+      BigInt(TEN_YEARS)
+    );
     expect(await wrapper.lastCollectionTimeOf(wrappedId)).to.equal(ZERO);
-    expect(await ethers.provider.getBalance(wrapper.address)).to.equal(
+    expect(await ethers.provider.getBalance(wrapperAddress)).to.equal(
       initialDeposit
     );
 
@@ -361,21 +433,24 @@ describe("Hardhat interoperability smokes", function () {
       TEN_YEARS,
       TAX_RATE_MINIMUM
     );
-    const takeoverRemittance = initialValuation
-      .add(initialDeposit)
-      .sub(takeoverTax);
-    const originatorBeforeTakeover = await originator.getBalance();
-    const buyerBeforeTakeover = await buyer.getBalance();
+    const takeoverRemittance = initialValuation + initialDeposit - takeoverTax;
+    const originatorBeforeTakeover = await ethers.provider.getBalance(
+      originatorAddress
+    );
+    const buyerBeforeTakeover = await ethers.provider.getBalance(buyerAddress);
 
     await setNextTimestamp(TAKEOVER_TIME);
-    const takeover = await wrapper
-      .connect(buyer)
-      .takeoverLease(wrappedId, buyerValuation, initialValuation, {
+    const takeover = await (wrapper.connect(buyer) as Contract).takeoverLease(
+      wrappedId,
+      buyerValuation,
+      initialValuation,
+      {
         value: initialValuation,
-      });
-    const takeoverReceipt = await takeover.wait();
+      }
+    );
+    const takeoverReceipt = await requiredReceipt(takeover);
     const takeoverEvents = decodeEvents(takeoverReceipt, [
-      { label: "wrapper", contract: wrapper },
+      await eventSource("wrapper", wrapper),
     ]);
 
     expect(eventNames(takeoverEvents)).to.deep.equal([
@@ -388,34 +463,30 @@ describe("Hardhat interoperability smokes", function () {
       "wrapper.LogLeaseTakeover",
     ]);
     expect(takeoverEvents[0].args.collected).to.equal(takeoverTax);
-    expect(takeoverEvents[1].args.trigger).to.equal(3);
-    expect(takeoverEvents[1].args.recipient).to.equal(buyer.address);
+    expect(takeoverEvents[1].args.trigger).to.equal(BigInt(3));
+    expect(takeoverEvents[1].args.recipient).to.equal(buyerAddress);
     expect(takeoverEvents[1].args.amount).to.equal(takeoverTax);
-    expect(takeoverEvents[2].args.trigger).to.equal(0);
-    expect(takeoverEvents[2].args.recipient).to.equal(originator.address);
+    expect(takeoverEvents[2].args.trigger).to.equal(BigInt(0));
+    expect(takeoverEvents[2].args.recipient).to.equal(originatorAddress);
     expect(takeoverEvents[2].args.amount).to.equal(takeoverRemittance);
     expect(takeoverEvents[3].args.newValuation).to.equal(buyerValuation);
-    expect(takeoverEvents[4].args.owner).to.equal(originator.address);
+    expect(takeoverEvents[4].args.owner).to.equal(originatorAddress);
     expect(takeoverEvents[4].args.approved).to.equal(ZERO_ADDRESS);
-    expect(takeoverEvents[5].args.from).to.equal(originator.address);
-    expect(takeoverEvents[5].args.to).to.equal(buyer.address);
-    expect(takeoverEvents[6].args.owner).to.equal(buyer.address);
+    expect(takeoverEvents[5].args.from).to.equal(originatorAddress);
+    expect(takeoverEvents[5].args.to).to.equal(buyerAddress);
+    expect(takeoverEvents[6].args.owner).to.equal(buyerAddress);
     expect(takeoverEvents[6].args.newValuation).to.equal(buyerValuation);
 
-    const takeoverGas = takeoverReceipt.gasUsed.mul(
-      takeoverReceipt.effectiveGasPrice
-    );
+    const takeoverGas = takeoverReceipt.gasUsed * takeoverReceipt.gasPrice;
     expect(
-      (await originator.getBalance()).sub(originatorBeforeTakeover)
+      (await ethers.provider.getBalance(originatorAddress)) -
+        originatorBeforeTakeover
     ).to.equal(takeoverRemittance);
-    expect(await buyer.getBalance()).to.equal(
-      buyerBeforeTakeover
-        .sub(initialValuation)
-        .add(takeoverTax)
-        .sub(takeoverGas)
+    expect(await ethers.provider.getBalance(buyerAddress)).to.equal(
+      buyerBeforeTakeover - initialValuation + takeoverTax - takeoverGas
     );
-    expect(await ethers.provider.getBalance(wrapper.address)).to.equal(ZERO);
-    expect(await wrapper.ownerOf(wrappedId)).to.equal(buyer.address);
+    expect(await ethers.provider.getBalance(wrapperAddress)).to.equal(ZERO);
+    expect(await wrapper.ownerOf(wrappedId)).to.equal(buyerAddress);
     expect(await wrapper.valuationOf(wrappedId)).to.equal(buyerValuation);
     expect(await wrapper.depositOf(wrappedId)).to.equal(ZERO);
     expect(await wrapper.taxationCollected(wrappedId)).to.equal(takeoverTax);
@@ -423,17 +494,19 @@ describe("Hardhat interoperability smokes", function () {
       ZERO
     );
     expect(await wrapper.lastCollectionTimeOf(wrappedId)).to.equal(
-      TAKEOVER_TIME
+      BigInt(TAKEOVER_TIME)
     );
-    expect(await nft.ownerOf(TOKEN_ID)).to.equal(wrapper.address);
+    expect(await nft.ownerOf(TOKEN_ID)).to.equal(wrapperAddress);
     expect(await wrapper.tokenURI(wrappedId)).to.equal("721.dev/1");
 
     await setNextTimestamp(UNWRAP_TIME);
-    const unwrap = await wrapper.connect(originator).unwrap(wrappedId);
-    const unwrapReceipt = await unwrap.wait();
+    const unwrap = await (wrapper.connect(originator) as Contract).unwrap(
+      wrappedId
+    );
+    const unwrapReceipt = await requiredReceipt(unwrap);
     const unwrapEvents = decodeEvents(unwrapReceipt, [
-      { label: "wrapper", contract: wrapper },
-      { label: "nft", contract: nft },
+      await eventSource("wrapper", wrapper),
+      await eventSource("nft", nft),
     ]);
 
     expect(eventNames(unwrapEvents)).to.deep.equal([
@@ -441,35 +514,40 @@ describe("Hardhat interoperability smokes", function () {
       "wrapper.Transfer",
       "nft.Transfer",
     ]);
-    expect(unwrapEvents[0].args.owner).to.equal(buyer.address);
+    expect(unwrapEvents[0].args.owner).to.equal(buyerAddress);
     expect(unwrapEvents[0].args.approved).to.equal(ZERO_ADDRESS);
-    expect(unwrapEvents[1].args.from).to.equal(buyer.address);
+    expect(unwrapEvents[1].args.from).to.equal(buyerAddress);
     expect(unwrapEvents[1].args.to).to.equal(ZERO_ADDRESS);
-    expect(unwrapEvents[2].args.from).to.equal(wrapper.address);
-    expect(unwrapEvents[2].args.to).to.equal(buyer.address);
+    expect(unwrapEvents[2].args.from).to.equal(wrapperAddress);
+    expect(unwrapEvents[2].args.to).to.equal(buyerAddress);
     expect(unwrapEvents[2].args.tokenId).to.equal(TOKEN_ID);
 
-    expect(await nft.ownerOf(TOKEN_ID)).to.equal(buyer.address);
+    expect(await nft.ownerOf(TOKEN_ID)).to.equal(buyerAddress);
     expect(await nft.getApproved(TOKEN_ID)).to.equal(ZERO_ADDRESS);
-    await expect(wrapper.ownerOf(wrappedId)).to.be.revertedWith(
+    await expectRevertReason(
+      wrapper.ownerOf(wrappedId),
       "ERC721: owner query for nonexistent token"
     );
-    await expect(wrapper.tokenURI(wrappedId)).to.be.revertedWith(
+    await expectRevertReason(
+      wrapper.tokenURI(wrappedId),
       "ERC721Metadata: URI query for nonexistent token"
     );
-    await expect(wrapper.depositOf(wrappedId)).to.be.revertedWith(
+    await expectRevertReason(
+      wrapper.depositOf(wrappedId),
       "ERC721: query for nonexistent token"
     );
-    await expect(wrapper.taxRateOf(wrappedId)).to.be.revertedWith(
+    await expectRevertReason(
+      wrapper.taxRateOf(wrappedId),
       "ERC721: query for nonexistent token"
     );
-    await expect(wrapper.collectionFrequencyOf(wrappedId)).to.be.revertedWith(
+    await expectRevertReason(
+      wrapper.collectionFrequencyOf(wrappedId),
       "ERC721: query for nonexistent token"
     );
     expect(await wrapper.valuationOf(wrappedId)).to.equal(ZERO);
     expect(await wrapper.beneficiaryOf(wrappedId)).to.equal(ZERO_ADDRESS);
     expect(await wrapper.taxationCollected(wrappedId)).to.equal(takeoverTax);
-    expect(await wrapper.balanceOf(buyer.address)).to.equal(ZERO);
-    expect(await ethers.provider.getBalance(wrapper.address)).to.equal(ZERO);
+    expect(await wrapper.balanceOf(buyerAddress)).to.equal(ZERO);
+    expect(await ethers.provider.getBalance(wrapperAddress)).to.equal(ZERO);
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
     "esModuleInterop": true,
     "outDir": "dist"
   },
-  "include": ["./scripts", "./tests"],
+  "include": ["./scripts", "./tests/Interoperability.smoke.ts"],
   "exclude": ["node_modules"],
   "files": ["./hardhat.config.ts"],
   "typeAcquisition": {


### PR DESCRIPTION
<!-- modernization-chronology:start -->
## Modernization chronology

- **Phase:** Stage 12a — ethers 6 interoperability migration
- **Predecessor:** [#95 — Foundry-first cutover](https://github.com/721labs/partial-common-ownership/pull/95)
- **This checkpoint:** [#96](https://github.com/721labs/partial-common-ownership/pull/96) — merged at [9a86ff5d001a4d3a06823712d0e70ad011987ecd](https://github.com/721labs/partial-common-ownership/commit/9a86ff5d001a4d3a06823712d0e70ad011987ecd) on 2026-07-17T00:30:14Z
- **Successor:** [#97 — Hardhat 3 migration](https://github.com/721labs/partial-common-ownership/pull/97)
- **Relationship:** Historical merge order: the three interoperability smokes moved to ethers 6 while temporary Hardhat 2 bridge debt remained explicit.
<!-- modernization-chronology:end -->

## Summary

- upgrade the active ethers runtime to exact 6.17.0 through the Hardhat 2-compatible Foundation plugin 3.1.3
- migrate the three retained interoperability smokes to ethers 6 while preserving their exact names, event order, balances, state, and revert assertions
- deactivate incompatible Waffle and TypeChain hooks while retaining their packages for isolated removal in Stage 12b
- add Stage 12a compatibility evidence and 39 negative policy probes anchored to the merged Stage 11 checkpoint

## Verification

- Hardhat smokes: 3/3
- Forge parity and safety: 140/140
- compatibility differences: 0
- package consumers, TypeScript, compiler warnings, coverage, gas, size, Slither, lint, formatting, frozen install, lock validation, and audit ratchet: pass
- production ABI, selectors, events, errors, storage, ERC165, bytecode, opcodes, sizes, compiler settings, and gas: exact Stage 11 equality

## Temporary bridge debt

The retained ethers-5-only Waffle, NomicLabs ethers, and TypeChain packages report one grouped peer mismatch but are not loaded or invoked. Stage 12b removes them together with the remaining obsolete Hardhat 2 tooling.
