### PR TITLE
ci: add append-only maintenance gate

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,6 +2,12 @@ name: "tests"
 
 on:
   workflow_dispatch:
+    inputs:
+      run_scheduled_safety:
+        description: "Run the 45-minute scheduled fuzz/invariant profile and upload its evidence"
+        required: false
+        default: false
+        type: boolean
   pull_request:
   schedule:
     - cron: "17 6 * * 1"
@@ -271,6 +277,8 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+          # The maintenance ledger verifies immutable historical checkpoints.
+          fetch-depth: 0
       - name: "Install Node"
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
@@ -384,7 +392,7 @@ jobs:
 
   foundry-scheduled:
     name: "Scheduled Foundry Safety"
-    if: ${{ github.event_name == 'schedule' }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_scheduled_safety) }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
     env:

--- a/compatibility/maintenance/0001-post-stage13-bootstrap.json
+++ b/compatibility/maintenance/0001-post-stage13-bootstrap.json
@@ -1,0 +1,126 @@
+{
+  "actions": {
+    "actions/cache": {
+      "commit": "0057852bfaa89a56745cba8c7296529d2fc39830",
+      "count": 10,
+      "tag": "v4.3.0"
+    },
+    "actions/checkout": {
+      "commit": "34e114876b0b11c390a56381ad16ebd13914f8d5",
+      "count": 10,
+      "tag": "v4.3.1"
+    },
+    "actions/setup-node": {
+      "commit": "49933ea5288caeca8642d1e84afbd3f7d6820020",
+      "count": 10,
+      "tag": "v4.4.0"
+    },
+    "actions/setup-python": {
+      "commit": "ece7cb06caefa5fff74198d8649806c4678c61a1",
+      "count": 1,
+      "tag": "v6.3.0"
+    },
+    "actions/upload-artifact": {
+      "commit": "ea165f8d65b6e75b540449e92b4886f43607fa02",
+      "count": 1,
+      "tag": "v4.6.2"
+    },
+    "foundry-rs/foundry-toolchain": {
+      "commit": "b00af27efadbc7b4ca8b82abbd903b17cc874d2a",
+      "count": 7,
+      "tag": "v1.9.0"
+    }
+  },
+  "baseCommit": "26e1082a21e2ef184253542c1bc8c10b87924d53",
+  "boundFiles": {
+    ".github/dependabot.yml": "b5e19b671186ac4e3541664d00a0ad13d4c30e64610847a0b59eaa71b40f77b4",
+    ".github/workflows/tests.yml": "25a9c2cc985528c586c50402910914187541ef5b69febdc18e8b895cec1ccdb8",
+    ".gitmodules": "ff4ebffecc8ab2a2a7320aa95762463fe80a4bc8acf0a4664d90d7c1adae75df",
+    ".nvmrc": "8f9258d5e9da5443c42966a661aee09292b49d1c64e718dcc5f72976500bac48",
+    "compatibility/audit-ratchet.json": "fc4fa90ddd1e9976339866df8497a5f4f697c79e4e28e66fe1d8f44e63845ffc",
+    "compatibility/baseline.json": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+    "compatibility/compiler-warning-allowlist.json": "9cae9f479731aba3a55a50418f66f1cb66fd59c6dbe19a44fed7415c9adf0763",
+    "compatibility/evidence/stage-13-ci-security-maintenance.json": "c7df59ea50e3a374723dd44cd061dc4b9ddd2722d3f3c8f67f8a437b702b5d07",
+    "compatibility/forge-lint-allowlist.json": "13f6a34e3b6fc4c9295ae578f24b1cebdea96a45cb01b69acf5996f5ee986ef7",
+    "compatibility/reviewed-differences.json": "d2cf786e11a28d1a2e661087c2ff4db7bb3accde6302f0e4fa46b550d0032123",
+    "compatibility/safety-baselines.json": "d70fb57f2dbf4671178fee515a583cb48ea5ea8e263a187dc0dec9a229ea4b5c",
+    "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a",
+    "compatibility/stage-13-ci-maintenance-inventory.json": "1ddf58ff2c58832c82c903b71180add027a18598633f9e39d81e5dffb5f9d420",
+    "coverage/lcov.info": "699bec5254479d496dd7fdf6366be2c5f1afe386585bfa4f2f4be0304735f575",
+    "docs/development.md": "26cfbbcbc40713083d3132654259b2779adc148a41ac5075492d1db1b286c899",
+    "foundry.toml": "15356b92e608367cc58458371448d51172a39ebc03fe461cd6fe77b21b3584a4",
+    "gas/key-flows.snap": "c57e387d3a71141ce69078dc051608e8eb1f5bccbddf5745f6d478d709b575f7",
+    "hardhat.config.ts": "8a01d6013e117f9d6dfbc230ec8d639e0fac0793404483c2c5ae775cebeec91c",
+    "package.json": "5fc4d4382bda9e03f94e826de4f21f318e38649a74ba0c8981e749d56edbf6bc",
+    "pnpm-lock.yaml": "c3498cc86b99ace2ab1810b24e886565aebf089fb35edc8132b0d774cc2a3ab5",
+    "pnpm-workspace.yaml": "6cf3f83b7611f5b240d4f3d86d230ab61fb48d989260d4fbec3d3f60f7ed763c",
+    "remappings.txt": "ff6af4f5f016d740713659bae831093a516370283d19a66bc5f2c43147772b42",
+    "scripts/audit-ratchet.cjs": "d52d7c69861b35dba286c99764c00b86da1be7505931c267d4ea7a8e87905128",
+    "scripts/check-ci-policy.cjs": "3a9faa55b451edf624ba13dbf3e3fafcb8c61d94899d882914ca8de7163bf840",
+    "scripts/check-compiler-warnings.cjs": "3f082e607c7abed11b822e767e14e7415a50671ec033e6655c10053686490b50",
+    "scripts/check-contract-sizes.cjs": "0c5e3e258c12fca1d946d0ecae7d36ad4ebbade97c3977179484977cd2cee6f7",
+    "scripts/check-coverage.cjs": "ec9d23cf30156793958b88fff8677170fd16cd8963515f30184df6ecc2216ee0",
+    "scripts/check-forge-lint.cjs": "409e188118effff4a0c4a25b1497b94adb779b9088c5a4fd2d859a98515a8416",
+    "scripts/check-gas.cjs": "22d9e8538b9e94379f80740cb054a1d48b2a5a1ee38d92b66583a6ef6876f3e8",
+    "scripts/check-parity.cjs": "f58a945d4236d61826a90c1954cecaa43ef1b3dc6602877eda8fd087eb292f21",
+    "scripts/check-safety-baselines.cjs": "9b2621e171cbad70df9badd72daaed38e50ba989b9ec3aa1917feef5df16b149",
+    "scripts/compatibility.cjs": "88d2b28b06e95150987637bd0bc5d11c7cb1a8ce15b2cfc1a003fe981646bcec",
+    "scripts/dependency-inventory.cjs": "6de23d7136ccef1dab89a1eefb082a07d542e50d54166c7641dfb032523e35e7",
+    "scripts/install.sh": "045b06f3d2f9705248aed669a252b41b5bd3285f44faf441127dbd62005a7b47",
+    "scripts/maintenance-policy.cjs": "30618c7c81a2a6fd4ba8b879d12c4ef6a931a3388b0f5d0996005305cdf0d27d",
+    "scripts/run-coverage.cjs": "03a4faf4616791c7ad306eef27ad85e9c7505a6d8ea63e474e1ab7b03913ccd7",
+    "scripts/run-slither.cjs": "f69835d298e6e5a373be883a966e2a6ea8d89eb3055ee1095c908a5b1b50f4fd",
+    "scripts/test-package.cjs": "505ee382e0869f9c04fbbb2fbcf0714ab459c06735ed3a747dba01fa7811bffe",
+    "slither.config.json": "cb2e3107f3f00d822eea68f92ab56b03b8efac79870017fbc94702232299add1",
+    "tsconfig.json": "d86cc63a05114438abb25258863b937cbc2a2b7433b6fe0ef83d274cec35a2b5"
+  },
+  "category": "bootstrap",
+  "changedFiles": [
+    ".github/workflows/tests.yml",
+    "scripts/check-ci-policy.cjs",
+    "scripts/check-parity.cjs",
+    "scripts/compatibility.cjs",
+    "scripts/maintenance-policy.cjs"
+  ],
+  "id": "post-stage13-bootstrap",
+  "packages": {
+    "dependencies": {
+      "@openzeppelin/contracts": "5.6.1"
+    },
+    "devDependencies": {
+      "@nomicfoundation/hardhat-ethers": "4.0.14",
+      "@types/node": "24.13.3",
+      "ethers": "6.17.0",
+      "hardhat": "3.9.1",
+      "tsx": "4.23.1",
+      "typescript": "7.0.2"
+    },
+    "packageManager": "pnpm@11.13.1"
+  },
+  "previous": {
+    "file": null,
+    "kind": "stage13",
+    "sha256": "19184bf72555ea0167b3dd50cafcb9e49f315e192010c22bcfcc26aede6bccd4"
+  },
+  "productionImpact": "none",
+  "schemaVersion": 1,
+  "sequence": 1,
+  "sourcePullRequests": [],
+  "summary": "Establish an append-only, transition-scoped dependency and CI maintenance gate after the frozen Stage 13 checkpoint.",
+  "toolchain": {
+    "bytecodeHash": "\"ipfs\"",
+    "cborMetadata": "true",
+    "evmVersion": "london",
+    "forgeStd": "bf647bd6046f2f7da30d0c2bf435e5c76a780c1b",
+    "node": "24.18.0",
+    "optimizer": "false",
+    "optimizerRuns": "200",
+    "pnpm": "11.13.1",
+    "solidity": "0.8.36",
+    "useLiteralContent": "false",
+    "viaIR": "false"
+  },
+  "transition": {
+    "kind": "bootstrap"
+  }
+}

--- a/scripts/check-ci-policy.cjs
+++ b/scripts/check-ci-policy.cjs
@@ -5,43 +5,32 @@
 const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
+const {
+  validateMaintenanceLedger,
+} = require("./maintenance-policy.cjs");
 
 const ROOT = path.resolve(__dirname, "..");
+const MAINTENANCE = validateMaintenanceLedger({ root: ROOT });
+const CURRENT_MAINTENANCE = MAINTENANCE.latest;
 const WORKFLOW_DIRECTORY = path.join(ROOT, ".github", "workflows");
 const WORKFLOW_PATH = path.join(WORKFLOW_DIRECTORY, "tests.yml");
 const DEPENDABOT_PATH = path.join(ROOT, ".github", "dependabot.yml");
 const GITMODULES_PATH = path.join(ROOT, ".gitmodules");
 const EXPECTED_WORKFLOW_SHA256 =
-  "1e58f24d752da7e9a2e68a89113d53b37898bc046896ca968b32ce7c535d4195";
+  CURRENT_MAINTENANCE.boundFiles[".github/workflows/tests.yml"];
 const EXPECTED_DEPENDABOT_SHA256 =
-  "b5e19b671186ac4e3541664d00a0ad13d4c30e64610847a0b59eaa71b40f77b4";
+  CURRENT_MAINTENANCE.boundFiles[".github/dependabot.yml"];
 
-const EXPECTED_ACTIONS = new Map([
-  [
-    "actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5",
-    { count: 10, tag: "v4.3.1" },
-  ],
-  [
-    "actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020",
-    { count: 10, tag: "v4.4.0" },
-  ],
-  [
-    "actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830",
-    { count: 10, tag: "v4.3.0" },
-  ],
-  [
-    "actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1",
-    { count: 1, tag: "v6.3.0" },
-  ],
-  [
-    "foundry-rs/foundry-toolchain@b00af27efadbc7b4ca8b82abbd903b17cc874d2a",
-    { count: 7, tag: "v1.9.0" },
-  ],
-  [
-    "actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02",
-    { count: 1, tag: "v4.6.2" },
-  ],
-]);
+const EXPECTED_ACTIONS = new Map(
+  Object.entries(CURRENT_MAINTENANCE.actions).map(([name, pin]) => [
+    `${name}@${pin.commit}`,
+    { count: pin.count, tag: pin.tag },
+  ])
+);
+const UPLOAD_ARTIFACT = CURRENT_MAINTENANCE.actions["actions/upload-artifact"];
+if (!UPLOAD_ARTIFACT) {
+  throw new Error("The maintenance record must bind actions/upload-artifact.");
+}
 
 const EXPECTED_JOBS = new Map([
   ["forge-tests", 15],
@@ -61,6 +50,12 @@ const FOUNDRY_JOBS = new Set([
   "coverage",
   "gas",
   "package-consumers",
+  "forge-quality",
+  "foundry-scheduled",
+]);
+const HISTORY_JOBS = new Set([
+  "forge-tests",
+  "compatibility",
   "forge-quality",
   "foundry-scheduled",
 ]);
@@ -216,7 +211,7 @@ const REQUIRED_STEPS = new Map([
       exactStep(
         "Upload minimized failures, seed, and log",
         `        if: \${{ always() }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@${UPLOAD_ARTIFACT.commit} # ${UPLOAD_ARTIFACT.tag}
         with:
           name: foundry-scheduled-\${{ github.run_id }}-\${{ github.run_attempt }}
           path: |
@@ -323,7 +318,7 @@ function checkWorkflow() {
     .split("\n")
     .filter((line) => /^\s+if\s*:/.test(line));
   const expectedConditionalLines = [
-    "    if: ${{ github.event_name == 'schedule' }}",
+    "    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.run_scheduled_safety) }}",
     "        if: ${{ always() }}",
   ];
   if (
@@ -334,6 +329,19 @@ function checkWorkflow() {
       `Workflow condition inventory changed: ${conditionalLines.join(" | ")}.`
     );
   }
+  const manualScheduledInput = `  workflow_dispatch:
+    inputs:
+      run_scheduled_safety:
+        description: "Run the 45-minute scheduled fuzz/invariant profile and upload its evidence"
+        required: false
+        default: false
+        type: boolean`;
+  assertCount(
+    workflow,
+    new RegExp(manualScheduledInput.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"), "g"),
+    1,
+    "opt-in manual scheduled-safety input"
+  );
 
   const permissions = workflow.match(
     /^permissions:\n((?:  [a-z-]+:\s*[^\n]+\n)+)/m
@@ -496,6 +504,12 @@ function checkWorkflow() {
       /^          persist-credentials: false$/gm,
       1,
       `${job} disabled checkout credentials`
+    );
+    assertCount(
+      checkout,
+      /^          fetch-depth: 0$/gm,
+      HISTORY_JOBS.has(job) ? 1 : 0,
+      `${job} immutable-checkpoint history`
     );
 
     const steps = parseSteps(job, body);

--- a/scripts/check-parity.cjs
+++ b/scripts/check-parity.cjs
@@ -6,6 +6,9 @@ const fs = require("fs");
 const crypto = require("crypto");
 const path = require("path");
 const { spawnSync } = require("child_process");
+const {
+  validateMaintenanceLedger,
+} = require("./maintenance-policy.cjs");
 
 const ROOT = path.resolve(__dirname, "..");
 const MAP_PATH = path.join(ROOT, "compatibility", "parity-map.json");
@@ -53,6 +56,8 @@ const STAGE_12B_CANDIDATE = "stage-12b-hardhat-3";
 const STAGE_13_CANDIDATE = "stage-13-ci-security-maintenance";
 const STAGE_13_POLICY = "stage-13-stage-12b-exact-equality";
 const STAGE_13_BASE_COMMIT = "bfdbcfaf84bd681c823487d1267139353df7ec37";
+const STAGE_13_CHECKPOINT_COMMIT =
+  "26e1082a21e2ef184253542c1bc8c10b87924d53";
 const STAGE_13_INVENTORY_PATH = path.join(
   ROOT,
   "compatibility",
@@ -163,6 +168,23 @@ function repositoryChangedPaths(baseCommit) {
     }
   }
   return sorted(changed);
+}
+
+function repositoryChangedPathsBetween(baseCommit, headCommit) {
+  const result = spawnSync(
+    "git",
+    ["diff", "--no-renames", "--name-only", baseCommit, headCommit],
+    {
+      cwd: ROOT,
+      encoding: "utf8",
+      maxBuffer: 128 * 1024 * 1024,
+    }
+  );
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    fail(`git diff ${baseCommit} ${headCommit} failed`);
+  }
+  return sorted(result.stdout.split(/\r?\n/).filter(Boolean));
 }
 
 function sha256(value) {
@@ -425,6 +447,7 @@ function stage13Inventory(stage12b) {
     STAGE_13_EVIDENCE_PATH,
     STAGE_13_REVIEW_PATH,
   ]) {
+    const relativePath = path.relative(ROOT, requiredPath);
     if (!fs.existsSync(requiredPath)) {
       fail(
         `Missing checked-in Stage 13 evidence: ${path.relative(
@@ -433,13 +456,33 @@ function stage13Inventory(stage12b) {
         )}`
       );
     }
+    if (
+      !fs
+        .readFileSync(requiredPath)
+        .equals(checkpointFile(STAGE_13_CHECKPOINT_COMMIT, relativePath))
+    ) {
+      fail(`Checked-in Stage 13 evidence changed: ${relativePath}`);
+    }
   }
 
-  const inventoryBytes = fs.readFileSync(STAGE_13_INVENTORY_PATH);
+  const inventoryBytes = checkpointFile(
+    STAGE_13_CHECKPOINT_COMMIT,
+    path.relative(ROOT, STAGE_13_INVENTORY_PATH)
+  );
   const inventory = JSON.parse(inventoryBytes);
   const inventorySha256 = sha256(inventoryBytes);
-  const review = readJson(STAGE_13_REVIEW_PATH);
-  const evidence = readJson(STAGE_13_EVIDENCE_PATH);
+  const review = JSON.parse(
+    checkpointFile(
+      STAGE_13_CHECKPOINT_COMMIT,
+      path.relative(ROOT, STAGE_13_REVIEW_PATH)
+    )
+  );
+  const evidence = JSON.parse(
+    checkpointFile(
+      STAGE_13_CHECKPOINT_COMMIT,
+      path.relative(ROOT, STAGE_13_EVIDENCE_PATH)
+    )
+  );
   const checkpoint = stage13CheckpointBinding();
   const flattenedCheckpoint = {
     commit: STAGE_13_BASE_COMMIT,
@@ -497,7 +540,12 @@ function stage13Inventory(stage12b) {
     evidence.maintenance?.inventory?.sha256 !== inventorySha256 ||
     !valuesEqual(review.maintenanceEvidence, evidence.maintenance) ||
     review.maintenanceEvidence.compatibilityRunnerSha256 !==
-      sha256(fs.readFileSync(path.join(ROOT, "scripts", "compatibility.cjs")))
+      sha256(
+        checkpointFile(
+          STAGE_13_CHECKPOINT_COMMIT,
+          "scripts/compatibility.cjs"
+        )
+      )
   ) {
     fail("Stage 13 maintenance evidence is stale");
   }
@@ -516,7 +564,7 @@ function stage13Inventory(stage12b) {
   for (const relativePath of inventory.addedFiles) {
     if (
       checkpointPathExists(STAGE_13_BASE_COMMIT, relativePath) ||
-      !fs.existsSync(path.join(ROOT, relativePath))
+      !checkpointPathExists(STAGE_13_CHECKPOINT_COMMIT, relativePath)
     ) {
       fail(`Stage 13 added-file classification changed: ${relativePath}`);
     }
@@ -524,7 +572,7 @@ function stage13Inventory(stage12b) {
   for (const relativePath of inventory.modifiedFiles) {
     if (
       !checkpointPathExists(STAGE_13_BASE_COMMIT, relativePath) ||
-      !fs.existsSync(path.join(ROOT, relativePath))
+      !checkpointPathExists(STAGE_13_CHECKPOINT_COMMIT, relativePath)
     ) {
       fail(`Stage 13 modified-file classification changed: ${relativePath}`);
     }
@@ -533,7 +581,8 @@ function stage13Inventory(stage12b) {
     inventory.boundFiles
   )) {
     if (
-      sha256(fs.readFileSync(path.join(ROOT, relativePath))) !== expectedSha256
+      sha256(checkpointFile(STAGE_13_CHECKPOINT_COMMIT, relativePath)) !==
+      expectedSha256
     ) {
       fail(`Stage 13 maintenance file changed: ${relativePath}`);
     }
@@ -550,7 +599,10 @@ function stage13Inventory(stage12b) {
   compareExact(
     "Stage 13 repository path inventory",
     expectedChangedPaths,
-    repositoryChangedPaths(STAGE_13_BASE_COMMIT)
+    repositoryChangedPathsBetween(
+      STAGE_13_BASE_COMMIT,
+      STAGE_13_CHECKPOINT_COMMIT
+    )
   );
   if (
     !valuesEqual(
@@ -750,6 +802,7 @@ function main() {
   const stage12a = stage12aInventory(stage11);
   const stage12b = stage12bInventory(stage12a);
   stage13Inventory(stage12b);
+  validateMaintenanceLedger({ root: ROOT });
   if (map.schemaVersion !== 1) fail("Unsupported parity-map schema");
   if (!Array.isArray(map.fragments) || map.fragments.length === 0) {
     fail("Parity map must list its cohort fragments");

--- a/scripts/compatibility.cjs
+++ b/scripts/compatibility.cjs
@@ -8,6 +8,9 @@ const os = require("os");
 const path = require("path");
 const { spawnSync } = require("child_process");
 const { verifySafetyBaselines } = require("./check-safety-baselines.cjs");
+const {
+  validateMaintenanceLedger,
+} = require("./maintenance-policy.cjs");
 
 const ROOT = path.resolve(__dirname, "..");
 const BASELINE_PATH = path.join(ROOT, "compatibility", "baseline.json");
@@ -1033,6 +1036,8 @@ const STAGE_13_POLICY = "stage-13-stage-12b-exact-equality";
 const STAGE_13_EVIDENCE_PATH =
   "compatibility/evidence/stage-13-ci-security-maintenance.json";
 const STAGE_13_BASE_COMMIT = "bfdbcfaf84bd681c823487d1267139353df7ec37";
+const STAGE_13_CHECKPOINT_COMMIT =
+  "26e1082a21e2ef184253542c1bc8c10b87924d53";
 const STAGE_13_STAGE_12B_EVIDENCE_SHA256 =
   "d5e4e569dd9698e5dad1326b29461b0fe01d25c13bc8ad72075e5a084bd0e998";
 const STAGE_13_STAGE_12B_REVIEW_SHA256 =
@@ -1380,6 +1385,19 @@ function repositoryChangedPaths(baseCommit) {
     if (relativePath) changed.add(relativePath);
   }
   return [...changed].sort();
+}
+
+function repositoryChangedPathsBetween(baseCommit, headCommit) {
+  return run("git", [
+    "diff",
+    "--no-renames",
+    "--name-only",
+    baseCommit,
+    headCommit,
+  ])
+    .stdout.split(/\r?\n/)
+    .filter(Boolean)
+    .sort();
 }
 
 function compilerSourceHashes() {
@@ -4746,7 +4764,25 @@ function stage12bSourceEvidence(candidate) {
 
 function stage13Inventory() {
   const inventoryPath = path.join(ROOT, STAGE_13_INVENTORY_PATH);
-  const bytes = fs.readFileSync(inventoryPath);
+  const readCheckpoint = (relativePath) =>
+    Buffer.from(
+      run("git", [
+        "show",
+        `${STAGE_13_CHECKPOINT_COMMIT}:${relativePath}`,
+      ]).stdout
+    );
+  for (const relativePath of [
+    "compatibility/baseline.json",
+    STAGE_13_EVIDENCE_PATH,
+    "compatibility/reviewed-differences.json",
+    STAGE_13_INVENTORY_PATH,
+  ]) {
+    const currentBytes = fs.readFileSync(path.join(ROOT, relativePath));
+    if (!currentBytes.equals(readCheckpoint(relativePath))) {
+      throw new Error(`Checked-in Stage 13 evidence changed: ${relativePath}`);
+    }
+  }
+  const bytes = readCheckpoint(STAGE_13_INVENTORY_PATH);
   const inventory = JSON.parse(bytes);
   if (
     sha256(bytes) !== STAGE_13_INVENTORY_SHA256 ||
@@ -4775,7 +4811,12 @@ function stage13Inventory() {
     throw new Error("Stage 13 maintenance file classification changed");
   }
   validateExactFileDigests(
-    fileDigestEvidence(inventory.boundFiles),
+    Object.fromEntries(
+      Object.keys(inventory.boundFiles).map((relativePath) => [
+        relativePath,
+        sha256(readCheckpoint(relativePath)),
+      ])
+    ),
     inventory.boundFiles,
     "stage13MaintenanceFiles"
   );
@@ -4785,7 +4826,12 @@ function stage13Inventory() {
       ["cat-file", "-e", `${STAGE_13_BASE_COMMIT}:${relativePath}`],
       { cwd: ROOT, encoding: "utf8" }
     );
-    if (result.status === 0 || !fs.existsSync(path.join(ROOT, relativePath))) {
+    const checkpointResult = spawnSync(
+      "git",
+      ["cat-file", "-e", `${STAGE_13_CHECKPOINT_COMMIT}:${relativePath}`],
+      { cwd: ROOT, encoding: "utf8" }
+    );
+    if (result.status === 0 || checkpointResult.status !== 0) {
       throw new Error(
         `Stage 13 added-file classification changed: ${relativePath}`
       );
@@ -4793,16 +4839,18 @@ function stage13Inventory() {
   }
   for (const relativePath of inventory.modifiedFiles) {
     run("git", ["cat-file", "-e", `${STAGE_13_BASE_COMMIT}:${relativePath}`]);
-    if (!fs.existsSync(path.join(ROOT, relativePath))) {
-      throw new Error(`Stage 13 modified file is missing: ${relativePath}`);
-    }
+    run("git", [
+      "cat-file",
+      "-e",
+      `${STAGE_13_CHECKPOINT_COMMIT}:${relativePath}`,
+    ]);
   }
 
   const basePackage = JSON.parse(
     run("git", ["show", `${STAGE_13_BASE_COMMIT}:package.json`]).stdout
   );
   const candidatePackage = JSON.parse(
-    fs.readFileSync(path.join(ROOT, "package.json"), "utf8")
+    readCheckpoint("package.json").toString("utf8")
   );
   const baseWithoutScripts = deepClone(basePackage);
   const candidateWithoutScripts = deepClone(candidatePackage);
@@ -4846,10 +4894,8 @@ function stage13Inventory() {
     `${STAGE_13_BASE_COMMIT}:lib/forge-std`,
   ]).stdout.trim();
   const candidateForgeStd = run("git", [
-    "-C",
-    "lib/forge-std",
     "rev-parse",
-    "HEAD",
+    `${STAGE_13_CHECKPOINT_COMMIT}:lib/forge-std`,
   ]).stdout.trim();
   if (
     baseForgeStd !== inventory.forgeStd.commit ||
@@ -4913,7 +4959,10 @@ function stage13MaintenanceEvidence() {
       sha256: STAGE_13_INVENTORY_SHA256,
     },
     changedPaths: validateStage13ChangedPaths(
-      repositoryChangedPaths(STAGE_13_BASE_COMMIT),
+      repositoryChangedPathsBetween(
+        STAGE_13_BASE_COMMIT,
+        STAGE_13_CHECKPOINT_COMMIT
+      ),
       inventory
     ),
     addedFiles: inventory.addedFiles,
@@ -4926,7 +4975,10 @@ function stage13MaintenanceEvidence() {
       sha256: checkpoint.evidence.sha256,
     },
     compatibilityRunnerSha256: sha256(
-      fs.readFileSync(path.join(ROOT, "scripts", "compatibility.cjs"))
+      run("git", [
+        "show",
+        `${STAGE_13_CHECKPOINT_COMMIT}:scripts/compatibility.cjs`,
+      ]).stdout
     ),
   });
 }
@@ -13605,6 +13657,8 @@ async function main() {
       `Refusing to overwrite the compatibility baseline at ${BASELINE_PATH}`
     );
   }
+
+  validateMaintenanceLedger({ root: ROOT });
 
   const manifest = await generateManifest();
   if (command === "revert-strings") {

--- a/scripts/maintenance-policy.cjs
+++ b/scripts/maintenance-policy.cjs
@@ -1,0 +1,964 @@
+#!/usr/bin/env node
+
+"use strict";
+
+const crypto = require("crypto");
+const fs = require("fs");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const STAGE_13_ANCHOR = Object.freeze({
+  commit: "26e1082a21e2ef184253542c1bc8c10b87924d53",
+  files: Object.freeze({
+    "compatibility/baseline.json":
+      "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+    "compatibility/evidence/stage-13-ci-security-maintenance.json":
+      "c7df59ea50e3a374723dd44cd061dc4b9ddd2722d3f3c8f67f8a437b702b5d07",
+    "compatibility/reviewed-differences.json":
+      "d2cf786e11a28d1a2e661087c2ff4db7bb3accde6302f0e4fa46b550d0032123",
+    "compatibility/stage-13-ci-maintenance-inventory.json":
+      "1ddf58ff2c58832c82c903b71180add027a18598633f9e39d81e5dffb5f9d420",
+    "scripts/check-ci-policy.cjs":
+      "007bf6e8b21f1939b1c54c2f032645988dc32c597bcc6b95101514956f805b1c",
+    "scripts/check-parity.cjs":
+      "7a5cf2140d8fa5e246a064f2dbc69b69ad0353aa1b7fb9ad1653907355222df1",
+    "scripts/compatibility.cjs":
+      "58f4f84f1fd8b8ab54d98d6c7f8d9364d45fca4dabc3c40382729d1050f4d8ff",
+  }),
+});
+
+const IMMUTABLE_STAGE_13_FILES = Object.freeze([
+  "compatibility/baseline.json",
+  "compatibility/evidence/stage-13-ci-security-maintenance.json",
+  "compatibility/reviewed-differences.json",
+  "compatibility/stage-13-ci-maintenance-inventory.json",
+]);
+
+const MANAGED_FILES = Object.freeze([
+  ".github/dependabot.yml",
+  ".github/workflows/tests.yml",
+  ".gitmodules",
+  ".nvmrc",
+  "compatibility/audit-ratchet.json",
+  "compatibility/baseline.json",
+  "compatibility/compiler-warning-allowlist.json",
+  "compatibility/evidence/stage-13-ci-security-maintenance.json",
+  "compatibility/forge-lint-allowlist.json",
+  "compatibility/reviewed-differences.json",
+  "compatibility/safety-baselines.json",
+  "compatibility/safety-test-inventory.json",
+  "compatibility/stage-13-ci-maintenance-inventory.json",
+  "coverage/lcov.info",
+  "docs/development.md",
+  "foundry.toml",
+  "gas/key-flows.snap",
+  "hardhat.config.ts",
+  "package.json",
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "remappings.txt",
+  "scripts/audit-ratchet.cjs",
+  "scripts/check-ci-policy.cjs",
+  "scripts/check-compiler-warnings.cjs",
+  "scripts/check-contract-sizes.cjs",
+  "scripts/check-coverage.cjs",
+  "scripts/check-forge-lint.cjs",
+  "scripts/check-gas.cjs",
+  "scripts/check-parity.cjs",
+  "scripts/check-safety-baselines.cjs",
+  "scripts/compatibility.cjs",
+  "scripts/dependency-inventory.cjs",
+  "scripts/install.sh",
+  "scripts/maintenance-policy.cjs",
+  "scripts/run-coverage.cjs",
+  "scripts/run-slither.cjs",
+  "scripts/test-package.cjs",
+  "slither.config.json",
+  "tsconfig.json",
+]);
+
+const BOOTSTRAP_CHANGED_FILES = Object.freeze([
+  ".github/workflows/tests.yml",
+  "scripts/check-ci-policy.cjs",
+  "scripts/check-parity.cjs",
+  "scripts/compatibility.cjs",
+  "scripts/maintenance-policy.cjs",
+]);
+
+const EXPECTED_ACTION_COUNTS = Object.freeze({
+  "actions/cache": 10,
+  "actions/checkout": 10,
+  "actions/setup-node": 10,
+  "actions/setup-python": 1,
+  "actions/upload-artifact": 1,
+  "foundry-rs/foundry-toolchain": 7,
+});
+
+const RECORD_DIRECTORY = "compatibility/maintenance";
+const RECORD_NAME = /^([0-9]{4})-([a-z0-9]+(?:-[a-z0-9]+)*)\.json$/;
+const EXACT_SEMVER = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+const EXACT_ACTION_TAG = /^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function sha256(value) {
+  return crypto.createHash("sha256").update(value).digest("hex");
+}
+
+function sorted(value) {
+  if (Array.isArray(value)) return value.map(sorted);
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.keys(value)
+        .sort()
+        .map((key) => [key, sorted(value[key])])
+    );
+  }
+  return value;
+}
+
+function stableJson(value) {
+  return `${JSON.stringify(sorted(value), null, 2)}\n`;
+}
+
+function valuesEqual(left, right) {
+  return stableJson(left) === stableJson(right);
+}
+
+function exactKeys(value, expected, label) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    !valuesEqual(Object.keys(value).sort(), [...expected].sort())
+  ) {
+    fail(`${label} has unexpected or missing fields`);
+  }
+}
+
+function runGit(root, args, { allowFailure = false } = {}) {
+  const result = spawnSync("git", args, {
+    cwd: root,
+    encoding: null,
+    maxBuffer: 64 * 1024 * 1024,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0 && !allowFailure) {
+    fail(
+      `git ${args.join(" ")} failed: ${Buffer.from(
+        result.stderr || ""
+      ).toString("utf8")}`
+    );
+  }
+  return result;
+}
+
+function checkedPath(root, relativePath) {
+  if (
+    typeof relativePath !== "string" ||
+    relativePath.length === 0 ||
+    path.isAbsolute(relativePath) ||
+    relativePath.split("/").includes("..")
+  ) {
+    fail(`Maintenance path must be repository-relative: ${relativePath}`);
+  }
+  const absolutePath = path.resolve(root, relativePath);
+  const rootPrefix = `${path.resolve(root)}${path.sep}`;
+  if (!absolutePath.startsWith(rootPrefix)) {
+    fail(`Maintenance path escaped the repository: ${relativePath}`);
+  }
+  return absolutePath;
+}
+
+function currentFileBytes(root, relativePath) {
+  const absolutePath = checkedPath(root, relativePath);
+  const stat = fs.lstatSync(absolutePath);
+  if (!stat.isFile() || stat.isSymbolicLink()) {
+    fail(`Maintenance-bound path must be a regular file: ${relativePath}`);
+  }
+  return fs.readFileSync(absolutePath);
+}
+
+function checkpointBytes(root, commit, relativePath, allowMissing = false) {
+  const result = runGit(root, ["show", `${commit}:${relativePath}`], {
+    allowFailure: allowMissing,
+  });
+  if (result.status !== 0) return null;
+  return Buffer.from(result.stdout);
+}
+
+function repositoryFileBytes(root, relativePath, reference = null) {
+  return reference === null
+    ? currentFileBytes(root, relativePath)
+    : checkpointBytes(root, reference, relativePath);
+}
+
+function fileSha256(root, relativePath, reference = null) {
+  return sha256(repositoryFileBytes(root, relativePath, reference));
+}
+
+function validateStage13Anchor(root) {
+  runGit(root, [
+    "merge-base",
+    "--is-ancestor",
+    STAGE_13_ANCHOR.commit,
+    "HEAD",
+  ]);
+  for (const [relativePath, expected] of Object.entries(
+    STAGE_13_ANCHOR.files
+  )) {
+    const bytes = checkpointBytes(root, STAGE_13_ANCHOR.commit, relativePath);
+    if (sha256(bytes) !== expected) {
+      fail(`Stage 13 anchor changed: ${relativePath}`);
+    }
+  }
+  for (const relativePath of IMMUTABLE_STAGE_13_FILES) {
+    if (fileSha256(root, relativePath) !== STAGE_13_ANCHOR.files[relativePath]) {
+      fail(`Checked-in Stage 13 evidence changed: ${relativePath}`);
+    }
+  }
+  return sorted(STAGE_13_ANCHOR);
+}
+
+function stage13AnchorSha256() {
+  return sha256(stableJson(STAGE_13_ANCHOR));
+}
+
+function boundFiles(root, reference = null, { allowMissing = false } = {}) {
+  return Object.fromEntries(
+    MANAGED_FILES.map((relativePath) => {
+      const bytes =
+        reference === null
+          ? repositoryFileBytes(root, relativePath)
+          : checkpointBytes(root, reference, relativePath, allowMissing);
+      if (bytes === null && !allowMissing) {
+        fail(`Maintenance-bound path is missing: ${relativePath}`);
+      }
+      return [relativePath, bytes === null ? null : sha256(bytes)];
+    })
+  );
+}
+
+function currentBoundFiles(root) {
+  return boundFiles(root);
+}
+
+function stage13BoundFiles(root) {
+  return boundFiles(root, STAGE_13_ANCHOR.commit, { allowMissing: true });
+}
+
+function parseActionSnapshot(workflowBytes) {
+  const workflow = workflowBytes.toString("utf8");
+  const actions = {};
+  for (const match of workflow.matchAll(
+    /^[ \t]*(?:-[ \t]+)?uses:\s*([^\s#]+)(?:\s+#\s*([^\n]+))?$/gm
+  )) {
+    const specification = match[1];
+    if (specification.startsWith("./")) continue;
+    const parsed = specification.match(/^([^@]+)@([0-9a-f]{40})$/);
+    if (!parsed) {
+      fail(`Action is not pinned by full commit SHA: ${specification}`);
+    }
+    const name = parsed[1];
+    if (!(name in EXPECTED_ACTION_COUNTS)) {
+      fail(`Workflow contains an unreviewed external action: ${name}`);
+    }
+    const tag = (match[2] || "").trim();
+    if (!EXACT_ACTION_TAG.test(tag)) {
+      fail(`Action pin is missing an exact release comment: ${specification}`);
+    }
+    const existing = actions[name];
+    if (existing && (existing.commit !== parsed[2] || existing.tag !== tag)) {
+      fail(`Action uses multiple pins: ${name}`);
+    }
+    actions[name] = {
+      commit: parsed[2],
+      count: (existing?.count || 0) + 1,
+      tag,
+    };
+  }
+  if (!valuesEqual(Object.keys(actions).sort(), Object.keys(EXPECTED_ACTION_COUNTS).sort())) {
+    fail("Workflow action-name inventory changed");
+  }
+  for (const [name, count] of Object.entries(EXPECTED_ACTION_COUNTS)) {
+    if (actions[name].count !== count) {
+      fail(`Workflow action count changed for ${name}`);
+    }
+  }
+  return sorted(actions);
+}
+
+function actionSnapshot(root, reference = null) {
+  return parseActionSnapshot(
+    repositoryFileBytes(root, ".github/workflows/tests.yml", reference)
+  );
+}
+
+function readPackage(root, reference = null) {
+  return JSON.parse(
+    repositoryFileBytes(root, "package.json", reference).toString("utf8")
+  );
+}
+
+function packageSnapshot(root, reference = null) {
+  const packageJson = readPackage(root, reference);
+  if (!/^pnpm@[0-9]+\.[0-9]+\.[0-9]+$/.test(packageJson.packageManager)) {
+    fail("packageManager must pin one exact pnpm release");
+  }
+  for (const group of ["dependencies", "devDependencies"]) {
+    for (const [name, version] of Object.entries(packageJson[group] || {})) {
+      if (!EXACT_SEMVER.test(version)) {
+        fail(`${group}.${name} is not pinned exactly: ${version}`);
+      }
+    }
+  }
+  const node = repositoryFileBytes(root, ".nvmrc", reference)
+    .toString("utf8")
+    .trim()
+    .replace(/^v/, "");
+  const nodeTypes = packageJson.devDependencies?.["@types/node"];
+  if (
+    nodeTypes &&
+    Number(nodeTypes.split(".")[0]) !== Number(node.split(".")[0])
+  ) {
+    fail(`@types/node ${nodeTypes} does not match the Node ${node} runtime major`);
+  }
+  return sorted({
+    dependencies: packageJson.dependencies || {},
+    devDependencies: packageJson.devDependencies || {},
+    packageManager: packageJson.packageManager,
+  });
+}
+
+function currentForgeStdGitlink(root) {
+  const index = runGit(root, ["ls-files", "-s", "--", "lib/forge-std"])
+    .stdout.toString("utf8")
+    .trim();
+  const match = index.match(/^160000 ([0-9a-f]{40}) 0\tlib\/forge-std$/);
+  if (!match) fail("forge-std must be a mode-160000 gitlink");
+  const submoduleHead = runGit(root, [
+    "-C",
+    "lib/forge-std",
+    "rev-parse",
+    "HEAD",
+  ])
+    .stdout.toString("utf8")
+    .trim();
+  const submoduleStatus = runGit(root, [
+    "-C",
+    "lib/forge-std",
+    "status",
+    "--porcelain",
+  ])
+    .stdout.toString("utf8")
+    .trim();
+  if (submoduleHead !== match[1] || submoduleStatus) {
+    fail("forge-std checkout must exactly match its clean gitlink");
+  }
+  return match[1];
+}
+
+function toolchainSnapshot(root, reference = null) {
+  const node = repositoryFileBytes(root, ".nvmrc", reference)
+    .toString("utf8")
+    .trim()
+    .replace(/^v/, "");
+  if (!EXACT_SEMVER.test(node)) {
+    fail(".nvmrc must pin one exact Node release");
+  }
+  const foundry = repositoryFileBytes(root, "foundry.toml", reference).toString(
+    "utf8"
+  );
+  const setting = (name) =>
+    foundry.match(new RegExp(`^${name}\\s*=\\s*([^\\n]+)$`, "m"))?.[1].trim();
+  const solidity = setting("solc_version")?.replace(/^"|"$/g, "");
+  const evmVersion = setting("evm_version")?.replace(/^"|"$/g, "");
+  if (!solidity || !evmVersion) fail("Foundry compiler settings are incomplete");
+  const forgeStd =
+    reference === null
+      ? currentForgeStdGitlink(root)
+      : runGit(root, ["rev-parse", `${reference}:lib/forge-std`])
+          .stdout.toString("utf8")
+          .trim();
+  if (!/^[0-9a-f]{40}$/.test(forgeStd)) {
+    fail("forge-std must be pinned to one gitlink commit");
+  }
+  return sorted({
+    bytecodeHash: setting("bytecode_hash"),
+    cborMetadata: setting("cbor_metadata"),
+    evmVersion,
+    forgeStd,
+    node,
+    optimizer: setting("optimizer"),
+    optimizerRuns: setting("optimizer_runs"),
+    pnpm: packageSnapshot(root, reference).packageManager.slice("pnpm@".length),
+    solidity,
+    useLiteralContent: setting("use_literal_content"),
+    viaIR: setting("via_ir"),
+  });
+}
+
+function expectedChangedFiles(previousBoundFiles, nextBoundFiles) {
+  return MANAGED_FILES.filter(
+    (relativePath) =>
+      previousBoundFiles[relativePath] !== nextBoundFiles[relativePath]
+  );
+}
+
+function changedPathsBetween(root, baseCommit, targetCommit) {
+  return runGit(root, [
+    "diff",
+    "--no-renames",
+    "--name-only",
+    baseCommit,
+    targetCommit,
+  ])
+    .stdout.toString("utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .sort();
+}
+
+function currentChangedPaths(root, baseCommit) {
+  const changed = new Set(
+    runGit(root, ["diff", "--no-renames", "--name-only", baseCommit])
+      .stdout.toString("utf8")
+      .split(/\r?\n/)
+      .filter(Boolean)
+  );
+  for (const relativePath of runGit(root, [
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+  ])
+    .stdout.toString("utf8")
+    .split(/\r?\n/)
+    .filter(Boolean)) {
+    changed.add(relativePath);
+  }
+  return [...changed].sort();
+}
+
+function recordFilesAt(root, reference) {
+  return runGit(root, [
+    "ls-tree",
+    "-r",
+    "--name-only",
+    reference,
+    "--",
+    RECORD_DIRECTORY,
+  ])
+    .stdout.toString("utf8")
+    .split(/\r?\n/)
+    .filter((relativePath) => relativePath.startsWith(`${RECORD_DIRECTORY}/`))
+    .map((relativePath) => relativePath.slice(RECORD_DIRECTORY.length + 1))
+    .sort();
+}
+
+function maintenanceHistory(root, currentFilenames) {
+  const commits = [
+    STAGE_13_ANCHOR.commit,
+    ...runGit(root, [
+      "rev-list",
+      "--first-parent",
+      "--reverse",
+      `${STAGE_13_ANCHOR.commit}..HEAD`,
+    ])
+      .stdout.toString("utf8")
+      .split(/\r?\n/)
+      .filter(Boolean),
+  ];
+  const historicalFilenames = new Set();
+  for (const commit of commits) {
+    for (const filename of recordFilesAt(root, commit)) {
+      historicalFilenames.add(filename);
+    }
+  }
+  const missing = [...historicalFilenames]
+    .filter((filename) => !currentFilenames.includes(filename))
+    .sort();
+  if (missing.length > 0) {
+    fail(`Append-only maintenance records were removed: ${missing.join(", ")}`);
+  }
+
+  const introductions = new Map();
+  for (const filename of currentFilenames) {
+    const relativePath = `${RECORD_DIRECTORY}/${filename}`;
+    let previous = null;
+    let introduction = null;
+    for (const commit of commits) {
+      const current = checkpointBytes(root, commit, relativePath, true);
+      if (previous === null && current !== null) {
+        if (introduction !== null) {
+          fail(`Maintenance record was reintroduced: ${relativePath}`);
+        }
+        introduction = commit;
+      } else if (previous !== null && current === null) {
+        fail(`Maintenance record was deleted: ${relativePath}`);
+      } else if (
+        previous !== null &&
+        current !== null &&
+        !previous.equals(current)
+      ) {
+        fail(`Maintenance record was modified after introduction: ${relativePath}`);
+      }
+      previous = current;
+    }
+    introductions.set(filename, introduction);
+  }
+
+  const introductionCommits = new Set(
+    [...introductions.values()].filter((commit) => commit !== null)
+  );
+  for (const commit of commits.slice(1)) {
+    const firstParent = runGit(root, ["rev-parse", `${commit}^1`])
+      .stdout.toString("utf8")
+      .trim();
+    const scopedPaths = maintenanceScopedPaths(
+      changedPathsBetween(root, firstParent, commit)
+    );
+    if (scopedPaths.length > 0 && !introductionCommits.has(commit)) {
+      fail(
+        `Managed files changed without a maintenance record in ${commit}: ${scopedPaths.join(", ")}`
+      );
+    }
+  }
+  return introductions;
+}
+
+function maintenanceScopedPaths(paths) {
+  const managed = new Set(MANAGED_FILES);
+  return paths.filter(
+    (relativePath) =>
+      managed.has(relativePath) ||
+      relativePath.startsWith(`${RECORD_DIRECTORY}/`)
+  );
+}
+
+function validateRecordSchema(record, filename, sequence) {
+  exactKeys(
+    record,
+    [
+      "actions",
+      "baseCommit",
+      "boundFiles",
+      "category",
+      "changedFiles",
+      "id",
+      "packages",
+      "previous",
+      "productionImpact",
+      "schemaVersion",
+      "sequence",
+      "sourcePullRequests",
+      "summary",
+      "toolchain",
+      "transition",
+    ],
+    `Maintenance record ${filename}`
+  );
+  if (
+    record.schemaVersion !== 1 ||
+    record.sequence !== sequence ||
+    record.id !== filename.replace(/^[0-9]{4}-|\.json$/g, "") ||
+    !/^[0-9a-f]{40}$/.test(record.baseCommit) ||
+    !["bootstrap", "github-actions", "javascript"].includes(record.category) ||
+    record.transition?.kind !== record.category ||
+    typeof record.summary !== "string" ||
+    record.summary.trim().length < 12 ||
+    record.productionImpact !== "none" ||
+    !Array.isArray(record.sourcePullRequests) ||
+    record.sourcePullRequests.some(
+      (number) => !Number.isInteger(number) || number <= 0
+    ) ||
+    !valuesEqual(
+      record.sourcePullRequests,
+      [...new Set(record.sourcePullRequests)].sort((left, right) => left - right)
+    )
+  ) {
+    fail(`Maintenance record has an invalid schema: ${filename}`);
+  }
+  if (sequence === 1) {
+    if (
+      record.category !== "bootstrap" ||
+      record.baseCommit !== STAGE_13_ANCHOR.commit ||
+      record.sourcePullRequests.length !== 0
+    ) {
+      fail("Record 0001 must be the exact post-Stage-13 bootstrap");
+    }
+  } else if (
+    record.category === "bootstrap" ||
+    record.sourcePullRequests.length === 0
+  ) {
+    fail("Routine maintenance records require PR provenance and cannot bootstrap");
+  }
+  if (
+    !valuesEqual(
+      Object.keys(record.boundFiles).sort(),
+      [...MANAGED_FILES].sort()
+    ) ||
+    Object.values(record.boundFiles).some(
+      (digest) => typeof digest !== "string" || !/^[0-9a-f]{64}$/.test(digest)
+    )
+  ) {
+    fail(`Maintenance record has an invalid bound-file snapshot: ${filename}`);
+  }
+  if (
+    !Array.isArray(record.changedFiles) ||
+    record.changedFiles.length === 0 ||
+    !valuesEqual(record.changedFiles, [...new Set(record.changedFiles)].sort())
+  ) {
+    fail(`Maintenance record changed-file inventory is invalid: ${filename}`);
+  }
+}
+
+function validateBootstrapTransition(record) {
+  exactKeys(record.transition, ["kind"], "Bootstrap transition");
+  if (!valuesEqual(record.changedFiles, BOOTSTRAP_CHANGED_FILES)) {
+    fail("Bootstrap may change only the workflow and four maintenance support scripts");
+  }
+}
+
+function validateActionDescriptor(value, label) {
+  exactKeys(value, ["commit", "tag"], label);
+  if (!/^[0-9a-f]{40}$/.test(value.commit) || !EXACT_ACTION_TAG.test(value.tag)) {
+    fail(`${label} must contain an exact action commit and release`);
+  }
+}
+
+function validateGithubActionTransition(
+  record,
+  beforeWorkflow,
+  afterWorkflow,
+  beforeActions,
+  afterActions
+) {
+  exactKeys(
+    record.transition,
+    ["action", "from", "kind", "occurrences", "to"],
+    "GitHub Actions transition"
+  );
+  const transition = record.transition;
+  if (
+    !valuesEqual(record.changedFiles, [".github/workflows/tests.yml"]) ||
+    !(transition.action in EXPECTED_ACTION_COUNTS) ||
+    !Number.isInteger(transition.occurrences) ||
+    transition.occurrences <= 0
+  ) {
+    fail("GitHub Actions maintenance must update one existing action pin only");
+  }
+  validateActionDescriptor(transition.from, "GitHub Action source");
+  validateActionDescriptor(transition.to, "GitHub Action target");
+  if (valuesEqual(transition.from, transition.to)) {
+    fail("GitHub Action transition is a no-op");
+  }
+  const beforePin = beforeActions[transition.action];
+  const afterPin = afterActions[transition.action];
+  if (
+    !beforePin ||
+    !afterPin ||
+    beforePin.commit !== transition.from.commit ||
+    beforePin.tag !== transition.from.tag ||
+    afterPin.commit !== transition.to.commit ||
+    afterPin.tag !== transition.to.tag ||
+    beforePin.count !== transition.occurrences ||
+    afterPin.count !== transition.occurrences
+  ) {
+    fail("GitHub Action transition does not match the bound action snapshots");
+  }
+  const expectedActions = structuredClone(beforeActions);
+  expectedActions[transition.action] = afterPin;
+  if (!valuesEqual(expectedActions, afterActions)) {
+    fail("GitHub Actions maintenance changed more than one action pin");
+  }
+  const source = `${transition.action}@${transition.from.commit} # ${transition.from.tag}`;
+  const replacement = `${transition.action}@${transition.to.commit} # ${transition.to.tag}`;
+  const beforeText = beforeWorkflow.toString("utf8");
+  const actualOccurrences = beforeText.split(source).length - 1;
+  if (
+    actualOccurrences !== transition.occurrences ||
+    beforeText.split(source).join(replacement) !== afterWorkflow.toString("utf8")
+  ) {
+    fail("Workflow changed outside the exact reviewed action-pin replacement");
+  }
+}
+
+function validateJavascriptTransition(record, beforePackage, afterPackage) {
+  exactKeys(
+    record.transition,
+    ["devDependencies", "kind"],
+    "JavaScript transition"
+  );
+  const changes = record.transition.devDependencies;
+  if (
+    !valuesEqual(record.changedFiles, ["package.json", "pnpm-lock.yaml"]) ||
+    !Array.isArray(changes) ||
+    changes.length === 0
+  ) {
+    fail("JavaScript maintenance must update package.json and pnpm-lock.yaml");
+  }
+  const names = [];
+  const expectedPackage = structuredClone(beforePackage);
+  for (const change of changes) {
+    exactKeys(change, ["from", "name", "to"], "Development dependency transition");
+    if (
+      typeof change.name !== "string" ||
+      !EXACT_SEMVER.test(change.from) ||
+      !EXACT_SEMVER.test(change.to) ||
+      change.from === change.to ||
+      beforePackage.devDependencies?.[change.name] !== change.from ||
+      afterPackage.devDependencies?.[change.name] !== change.to
+    ) {
+      fail(`Invalid existing development dependency transition: ${change.name}`);
+    }
+    names.push(change.name);
+    expectedPackage.devDependencies[change.name] = change.to;
+  }
+  if (!valuesEqual(names, [...new Set(names)].sort())) {
+    fail("Development dependency transitions must be unique and sorted");
+  }
+  if (!valuesEqual(expectedPackage, afterPackage)) {
+    fail("package.json changed outside declared existing devDependencies");
+  }
+}
+
+function validateTransition(
+  root,
+  record,
+  baseCommit,
+  targetReference,
+  beforeActions,
+  afterActions,
+  beforePackages,
+  afterPackages,
+  beforeToolchain,
+  afterToolchain
+) {
+  if (record.category === "bootstrap") {
+    validateBootstrapTransition(record);
+    return;
+  }
+  if (!valuesEqual(beforeToolchain, afterToolchain)) {
+    fail("Routine dependency maintenance may not change the pinned toolchain");
+  }
+  if (record.category === "github-actions") {
+    if (!valuesEqual(beforePackages, afterPackages)) {
+      fail("GitHub Actions maintenance may not change JavaScript packages");
+    }
+    validateGithubActionTransition(
+      record,
+      repositoryFileBytes(root, ".github/workflows/tests.yml", baseCommit),
+      repositoryFileBytes(root, ".github/workflows/tests.yml", targetReference),
+      beforeActions,
+      afterActions
+    );
+    return;
+  }
+  if (!valuesEqual(beforeActions, afterActions)) {
+    fail("JavaScript maintenance may not change GitHub Actions");
+  }
+  validateJavascriptTransition(
+    record,
+    readPackage(root, baseCommit),
+    readPackage(root, targetReference)
+  );
+}
+
+function validateMaintenanceLedger({ root = path.resolve(__dirname, "..") } = {}) {
+  root = path.resolve(root);
+  const stage13 = validateStage13Anchor(root);
+  const directory = checkedPath(root, RECORD_DIRECTORY);
+  if (!fs.existsSync(directory) || !fs.lstatSync(directory).isDirectory()) {
+    fail("The append-only maintenance record directory is missing");
+  }
+  const entries = fs.readdirSync(directory, { withFileTypes: true });
+  if (entries.some((entry) => !entry.isFile() || entry.isSymbolicLink())) {
+    fail("Maintenance record directory may contain regular JSON files only");
+  }
+  const filenames = entries.map((entry) => entry.name).sort();
+  if (filenames.length === 0 || filenames.some((name) => !RECORD_NAME.test(name))) {
+    fail("Maintenance records must use zero-padded immutable JSON filenames");
+  }
+  const introductions = maintenanceHistory(root, filenames);
+
+  const records = [];
+  let previousBytes = null;
+  let previousBoundFiles = stage13BoundFiles(root);
+  let previousActions = actionSnapshot(root, STAGE_13_ANCHOR.commit);
+  let previousPackages = packageSnapshot(root, STAGE_13_ANCHOR.commit);
+  let previousToolchain = toolchainSnapshot(root, STAGE_13_ANCHOR.commit);
+
+  for (const [index, filename] of filenames.entries()) {
+    const sequence = index + 1;
+    const match = filename.match(RECORD_NAME);
+    if (Number(match[1]) !== sequence) {
+      fail(`Maintenance record sequence has a gap: ${filename}`);
+    }
+    const relativePath = `${RECORD_DIRECTORY}/${filename}`;
+    const bytes = currentFileBytes(root, relativePath);
+    const record = JSON.parse(bytes);
+    if (bytes.toString("utf8") !== stableJson(record)) {
+      fail(`Maintenance record is not canonical JSON: ${filename}`);
+    }
+    validateRecordSchema(record, filename, sequence);
+
+    const expectedPrevious =
+      sequence === 1
+        ? { file: null, kind: "stage13", sha256: stage13AnchorSha256() }
+        : {
+            file: filenames[index - 1],
+            kind: "maintenance",
+            sha256: sha256(previousBytes),
+          };
+    if (!valuesEqual(record.previous, expectedPrevious)) {
+      fail(`Maintenance record predecessor changed: ${filename}`);
+    }
+
+    runGit(root, ["merge-base", "--is-ancestor", record.baseCommit, "HEAD"]);
+    if (
+      sequence > 1 &&
+      maintenanceScopedPaths(
+        changedPathsBetween(
+          root,
+          records[index - 1].introduction,
+          record.baseCommit
+        )
+      ).length !== 0
+    ) {
+      fail(`Maintenance base contains unrecorded managed changes: ${filename}`);
+    }
+    if (!valuesEqual(recordFilesAt(root, record.baseCommit), filenames.slice(0, index))) {
+      fail(`Maintenance base has an invalid record history: ${filename}`);
+    }
+    if (!valuesEqual(boundFiles(root, record.baseCommit, { allowMissing: true }), previousBoundFiles)) {
+      fail(`Maintenance base does not match its predecessor snapshot: ${filename}`);
+    }
+    if (
+      !valuesEqual(actionSnapshot(root, record.baseCommit), previousActions) ||
+      !valuesEqual(packageSnapshot(root, record.baseCommit), previousPackages) ||
+      !valuesEqual(toolchainSnapshot(root, record.baseCommit), previousToolchain)
+    ) {
+      fail(`Maintenance base toolchain does not match its predecessor: ${filename}`);
+    }
+
+    const introduction = introductions.get(filename);
+    if (introduction !== null) {
+      const introducedBytes = checkpointBytes(root, introduction, relativePath);
+      if (!introducedBytes.equals(bytes)) {
+        fail(`Maintenance record history is not append-only: ${relativePath}`);
+      }
+      runGit(root, [
+        "merge-base",
+        "--is-ancestor",
+        record.baseCommit,
+        introduction,
+      ]);
+      const firstParent = runGit(root, ["rev-parse", `${introduction}^1`])
+        .stdout.toString("utf8")
+        .trim();
+      if (record.baseCommit !== firstParent) {
+        fail(`Maintenance record must be based on its introduction's first parent: ${filename}`);
+      }
+    } else {
+      const head = runGit(root, ["rev-parse", "HEAD"])
+        .stdout.toString("utf8")
+        .trim();
+      if (index !== filenames.length - 1 || record.baseCommit !== head) {
+        fail(`Only one latest local record may be uncommitted: ${filename}`);
+      }
+    }
+    const targetReference = introduction;
+    const targetBoundFiles = boundFiles(root, targetReference);
+    const targetActions = actionSnapshot(root, targetReference);
+    const targetPackages = packageSnapshot(root, targetReference);
+    const targetToolchain = toolchainSnapshot(root, targetReference);
+    if (
+      !valuesEqual(record.boundFiles, targetBoundFiles) ||
+      !valuesEqual(record.actions, targetActions) ||
+      !valuesEqual(record.packages, targetPackages) ||
+      !valuesEqual(record.toolchain, targetToolchain)
+    ) {
+      fail(`Maintenance record does not bind its introduction tree: ${filename}`);
+    }
+    const changedFiles = expectedChangedFiles(previousBoundFiles, targetBoundFiles);
+    if (!valuesEqual(record.changedFiles, changedFiles)) {
+      fail(`Maintenance record changed-file inventory is stale: ${filename}`);
+    }
+    const actualPaths =
+      targetReference === null
+        ? currentChangedPaths(root, record.baseCommit)
+        : changedPathsBetween(root, record.baseCommit, targetReference);
+    const expectedPaths = [...record.changedFiles, relativePath].sort();
+    if (!valuesEqual(actualPaths, expectedPaths)) {
+      fail(`Maintenance repository delta is not exact: ${filename}`);
+    }
+    validateTransition(
+      root,
+      record,
+      record.baseCommit,
+      targetReference,
+      previousActions,
+      targetActions,
+      previousPackages,
+      targetPackages,
+      previousToolchain,
+      targetToolchain
+    );
+
+    records.push({
+      ...record,
+      filename,
+      introduction,
+      sha256: sha256(bytes),
+    });
+    previousBytes = bytes;
+    previousBoundFiles = targetBoundFiles;
+    previousActions = targetActions;
+    previousPackages = targetPackages;
+    previousToolchain = targetToolchain;
+  }
+
+  const latest = records.at(-1);
+  if (
+    !valuesEqual(currentBoundFiles(root), latest.boundFiles) ||
+    !valuesEqual(actionSnapshot(root), latest.actions) ||
+    !valuesEqual(packageSnapshot(root), latest.packages) ||
+    !valuesEqual(toolchainSnapshot(root), latest.toolchain)
+  ) {
+    fail("Current managed files do not match the latest maintenance record");
+  }
+  if (latest.introduction !== null) {
+    const unrecorded = maintenanceScopedPaths(
+      currentChangedPaths(root, latest.introduction)
+    );
+    if (unrecorded.length !== 0) {
+      fail(`Managed files changed after the latest maintenance record: ${unrecorded.join(", ")}`);
+    }
+  }
+  return sorted({ latest, records, stage13 });
+}
+
+module.exports = Object.freeze({
+  BOOTSTRAP_CHANGED_FILES,
+  MANAGED_FILES,
+  STAGE_13_ANCHOR,
+  actionSnapshot,
+  currentBoundFiles,
+  packageSnapshot,
+  sha256,
+  stableJson,
+  stage13AnchorSha256,
+  toolchainSnapshot,
+  validateGithubActionTransition,
+  validateJavascriptTransition,
+  validateMaintenanceLedger,
+});
+
+if (require.main === module) {
+  const result = validateMaintenanceLedger();
+  console.log(
+    `Maintenance policy passed: ${result.records.length} append-only record(s), latest ${result.latest.filename}.`
+  );
+}


### PR DESCRIPTION
<!-- modernization-chronology:start -->
## Modernization chronology

- **Phase:** Post-Stage-13 maintenance bootstrap
- **Predecessor:** [#98 — modernization endpoint](https://github.com/721labs/partial-common-ownership/pull/98)
- **This checkpoint:** [#105](https://github.com/721labs/partial-common-ownership/pull/105) — merged at [084b217f35124e33c5bee63353a894d9ad5c2057](https://github.com/721labs/partial-common-ownership/commit/084b217f35124e33c5bee63353a894d9ad5c2057) on 2026-07-17T15:14:50Z
- **Successor:** [#99 — actions/checkout v7 maintenance](https://github.com/721labs/partial-common-ownership/pull/99)
- **Relationship:** Maintenance-series start: establishes the append-only policy that governs each later dependency transition.
<!-- modernization-chronology:end -->

<!-- maintenance-review-record:start -->
## Reviewer record

### Why and exact scope

Stage 13 (#98, commit 26e1082a21e2ef184253542c1bc8c10b87924d53) intentionally froze CI and compatibility evidence. That made unreviewed drift impossible, but it also meant legitimate Dependabot changes could not pass. This PR creates the narrow post-Stage-13 path for routine maintenance without regenerating or weakening the frozen baseline.

- **Exact transition:** Adds sequence 1, compatibility/maintenance/0001-post-stage13-bootstrap.json, and binds the current workflow, package graph, toolchain, evidence, action pins, and support scripts. It also adds an opt-in workflow_dispatch input for exercising the scheduled safety/artifact path on an exact PR head.
- **Repository boundary:** Six files only: .github/workflows/tests.yml, the sequence-1 record, scripts/maintenance-policy.cjs, and the three compatibility/CI policy integration scripts. No production contract, package version, lockfile, compiler setting, submodule, public interface, bytecode baseline, or runtime behavior changes.
- **Production impact:** none unless explicitly stated above.

### Risk, compatibility, and rollback

The main risk is policy bypass or false acceptance. The validator therefore checks each first-parent commit, including change-then-restore history, record immutability, exact base-parent relationships, exact action/package transitions, and frozen Stage 13 bytes.

- **Rollback rule:** Do not delete or rewrite the sequence-1 record. Any rollback must be a new reviewed PR that preserves the append-only history and explicitly restores the prior policy state.

### Verification and final disposition

- node scripts/maintenance-policy.cjs — sequence 1 accepted; an adversarial two-commit change-then-restore probe was rejected
- pnpm ci:policy — 10 jobs, 39 immutable action uses, and 3 Dependabot ecosystems accepted
- pnpm test:safety — 89 Hardhat plus 15 baseline Forge scenarios mapped to 104 behavior tests, plus 36 safety tests
- pnpm compatibility — 3 Hardhat plus 140 Forge tests; 0 reviewed Stage 13 differences
- [GitHub Actions run 29591122775](https://github.com/721labs/partial-common-ownership/actions/runs/29591122775) — all nine required jobs passed; Scheduled Foundry Safety was correctly skipped for pull_request.
- **Outcome:** Merged on 2026-07-17T15:14:50Z from exact head 69bc6f5b290c2ae678c3bd2a76f6a5d4341565d5 as squash commit 084b217f35124e33c5bee63353a894d9ad5c2057.
<!-- maintenance-review-record:end -->

## Summary

- preserve the frozen Stage 13 compatibility checkpoint while allowing narrowly declared dependency maintenance
- require one canonical, append-only maintenance record per action or JavaScript dependency transition
- reject undeclared workflow/package/toolchain changes, record rewrites, and change-then-restore history
- add an explicit opt-in dispatch path for proving the scheduled Foundry/artifact job on an exact PR SHA

## Verification

- maintenance policy and adversarial change-then-restore negative probe
- CI policy
- 89 Hardhat + 15 baseline Forge scenario parity, plus 36 safety tests
- 3 Hardhat + 140 Forge compatibility tests with 0 reviewed differences
- full local Stage 13 quality/security/package/audit matrix
