### PR TITLE
ci: support reviewed JavaScript security overrides

### DIFF
--- a/compatibility/maintenance/0006-security-override-policy.json
+++ b/compatibility/maintenance/0006-security-override-policy.json
@@ -1,0 +1,137 @@
+{
+  "actions": {
+    "actions/cache": {
+      "commit": "55cc8345863c7cc4c66a329aec7e433d2d1c52a9",
+      "count": 10,
+      "tag": "v6.1.0"
+    },
+    "actions/checkout": {
+      "commit": "9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "count": 10,
+      "tag": "v7.0.0"
+    },
+    "actions/setup-node": {
+      "commit": "820762786026740c76f36085b0efc47a31fe5020",
+      "count": 10,
+      "tag": "v7.0.0"
+    },
+    "actions/setup-python": {
+      "commit": "ece7cb06caefa5fff74198d8649806c4678c61a1",
+      "count": 1,
+      "tag": "v6.3.0"
+    },
+    "actions/upload-artifact": {
+      "commit": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
+      "count": 1,
+      "tag": "v7.0.1"
+    },
+    "foundry-rs/foundry-toolchain": {
+      "commit": "b00af27efadbc7b4ca8b82abbd903b17cc874d2a",
+      "count": 7,
+      "tag": "v1.9.0"
+    }
+  },
+  "baseCommit": "318ad540bf4dd95810db4b0380fe67734b726fab",
+  "boundFiles": {
+    ".github/dependabot.yml": "b5e19b671186ac4e3541664d00a0ad13d4c30e64610847a0b59eaa71b40f77b4",
+    ".github/workflows/tests.yml": "a73934e355b5a360c7baf48396b4ee80df887dd130c93a391587a6c2aaa57f1e",
+    ".gitmodules": "ff4ebffecc8ab2a2a7320aa95762463fe80a4bc8acf0a4664d90d7c1adae75df",
+    ".nvmrc": "8f9258d5e9da5443c42966a661aee09292b49d1c64e718dcc5f72976500bac48",
+    "compatibility/audit-ratchet.json": "fc4fa90ddd1e9976339866df8497a5f4f697c79e4e28e66fe1d8f44e63845ffc",
+    "compatibility/baseline.json": "4ec069e1cdb046198456b1db9179522b604d8dab062838c79e4cf8aa1e9df55c",
+    "compatibility/compiler-warning-allowlist.json": "9cae9f479731aba3a55a50418f66f1cb66fd59c6dbe19a44fed7415c9adf0763",
+    "compatibility/evidence/stage-13-ci-security-maintenance.json": "c7df59ea50e3a374723dd44cd061dc4b9ddd2722d3f3c8f67f8a437b702b5d07",
+    "compatibility/forge-lint-allowlist.json": "13f6a34e3b6fc4c9295ae578f24b1cebdea96a45cb01b69acf5996f5ee986ef7",
+    "compatibility/reviewed-differences.json": "d2cf786e11a28d1a2e661087c2ff4db7bb3accde6302f0e4fa46b550d0032123",
+    "compatibility/safety-baselines.json": "d70fb57f2dbf4671178fee515a583cb48ea5ea8e263a187dc0dec9a229ea4b5c",
+    "compatibility/safety-test-inventory.json": "52f7c77b9ebec5093ad484f6695e46194b3ed0b9e737943946843e4f19c4d83a",
+    "compatibility/stage-13-ci-maintenance-inventory.json": "1ddf58ff2c58832c82c903b71180add027a18598633f9e39d81e5dffb5f9d420",
+    "coverage/lcov.info": "699bec5254479d496dd7fdf6366be2c5f1afe386585bfa4f2f4be0304735f575",
+    "docs/development.md": "26cfbbcbc40713083d3132654259b2779adc148a41ac5075492d1db1b286c899",
+    "foundry.toml": "15356b92e608367cc58458371448d51172a39ebc03fe461cd6fe77b21b3584a4",
+    "gas/key-flows.snap": "c57e387d3a71141ce69078dc051608e8eb1f5bccbddf5745f6d478d709b575f7",
+    "hardhat.config.ts": "8a01d6013e117f9d6dfbc230ec8d639e0fac0793404483c2c5ae775cebeec91c",
+    "package.json": "5fc4d4382bda9e03f94e826de4f21f318e38649a74ba0c8981e749d56edbf6bc",
+    "pnpm-lock.yaml": "539c6d4cd7c765890bccbb2d40e8ebb20cb6cb6b69a3d0bdb9ad86107ee340a1",
+    "pnpm-workspace.yaml": "1277d5a662724d4a106bb2bd32c07c67de55a4e43ebf731c97a3804c7dd187d5",
+    "remappings.txt": "ff6af4f5f016d740713659bae831093a516370283d19a66bc5f2c43147772b42",
+    "scripts/audit-ratchet.cjs": "d52d7c69861b35dba286c99764c00b86da1be7505931c267d4ea7a8e87905128",
+    "scripts/check-ci-policy.cjs": "3a9faa55b451edf624ba13dbf3e3fafcb8c61d94899d882914ca8de7163bf840",
+    "scripts/check-compiler-warnings.cjs": "3f082e607c7abed11b822e767e14e7415a50671ec033e6655c10053686490b50",
+    "scripts/check-contract-sizes.cjs": "0c5e3e258c12fca1d946d0ecae7d36ad4ebbade97c3977179484977cd2cee6f7",
+    "scripts/check-coverage.cjs": "ec9d23cf30156793958b88fff8677170fd16cd8963515f30184df6ecc2216ee0",
+    "scripts/check-forge-lint.cjs": "409e188118effff4a0c4a25b1497b94adb779b9088c5a4fd2d859a98515a8416",
+    "scripts/check-gas.cjs": "22d9e8538b9e94379f80740cb054a1d48b2a5a1ee38d92b66583a6ef6876f3e8",
+    "scripts/check-parity.cjs": "f58a945d4236d61826a90c1954cecaa43ef1b3dc6602877eda8fd087eb292f21",
+    "scripts/check-safety-baselines.cjs": "9b2621e171cbad70df9badd72daaed38e50ba989b9ec3aa1917feef5df16b149",
+    "scripts/compatibility.cjs": "88d2b28b06e95150987637bd0bc5d11c7cb1a8ce15b2cfc1a003fe981646bcec",
+    "scripts/dependency-inventory.cjs": "6de23d7136ccef1dab89a1eefb082a07d542e50d54166c7641dfb032523e35e7",
+    "scripts/install.sh": "045b06f3d2f9705248aed669a252b41b5bd3285f44faf441127dbd62005a7b47",
+    "scripts/maintenance-policy.cjs": "6480620e463819870a9e307de7ede212f45fd700d7fa186156a0b19f74092687",
+    "scripts/run-coverage.cjs": "03a4faf4616791c7ad306eef27ad85e9c7505a6d8ea63e474e1ab7b03913ccd7",
+    "scripts/run-slither.cjs": "f69835d298e6e5a373be883a966e2a6ea8d89eb3055ee1095c908a5b1b50f4fd",
+    "scripts/test-package.cjs": "505ee382e0869f9c04fbbb2fbcf0714ab459c06735ed3a747dba01fa7811bffe",
+    "slither.config.json": "cb2e3107f3f00d822eea68f92ab56b03b8efac79870017fbc94702232299add1",
+    "tsconfig.json": "d86cc63a05114438abb25258863b937cbc2a2b7433b6fe0ef83d274cec35a2b5"
+  },
+  "category": "governance",
+  "changedFiles": [
+    "pnpm-lock.yaml",
+    "pnpm-workspace.yaml",
+    "scripts/maintenance-policy.cjs"
+  ],
+  "id": "security-override-policy",
+  "packages": {
+    "dependencies": {
+      "@openzeppelin/contracts": "5.6.1"
+    },
+    "devDependencies": {
+      "@nomicfoundation/hardhat-ethers": "4.0.14",
+      "@types/node": "24.13.3",
+      "ethers": "6.17.0",
+      "hardhat": "3.9.1",
+      "tsx": "4.23.1",
+      "typescript": "7.0.2"
+    },
+    "packageManager": "pnpm@11.13.1"
+  },
+  "previous": {
+    "file": "0005-upload-artifact-7.json",
+    "kind": "maintenance",
+    "sha256": "f6ae6c4d39a981cb0f321777496d675fc38124adc674405684e1c45c5e232cd8"
+  },
+  "productionImpact": "none",
+  "schemaVersion": 1,
+  "sequence": 6,
+  "sourcePullRequests": [
+    106
+  ],
+  "summary": "Add an exact advisory-backed pnpm override and allow matching Hardhat warning metadata in append-only JavaScript maintenance records.",
+  "toolchain": {
+    "bytecodeHash": "\"ipfs\"",
+    "cborMetadata": "true",
+    "evmVersion": "london",
+    "forgeStd": "bf647bd6046f2f7da30d0c2bf435e5c76a780c1b",
+    "node": "24.18.0",
+    "optimizer": "false",
+    "optimizerRuns": "200",
+    "pnpm": "11.13.1",
+    "solidity": "0.8.36",
+    "useLiteralContent": "false",
+    "viaIR": "false"
+  },
+  "transition": {
+    "fromSha256": "30618c7c81a2a6fd4ba8b879d12c4ef6a931a3388b0f5d0996005305cdf0d27d",
+    "kind": "governance",
+    "path": "scripts/maintenance-policy.cjs",
+    "securityOverrides": [
+      {
+        "advisory": "GHSA-xcpc-8h2w-3j85",
+        "from": null,
+        "name": "adm-zip",
+        "to": "0.6.0"
+      }
+    ],
+    "toSha256": "6480620e463819870a9e307de7ede212f45fd700d7fa186156a0b19f74092687"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  adm-zip: 0.6.0
+
 importers:
 
   .:
@@ -448,9 +451,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  adm-zip@0.4.16:
-    resolution: {integrity: sha512-TFi4HBKSGfIKsK5YCkKaaFG2m4PEDyViZmEwof3MTIgzimHLto6muaHVpbrljdIvIrFZzEq/p4nafOeLcYegrg==}
-    engines: {node: '>=0.3.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   aes-js@4.0.0-beta.5:
     resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
@@ -859,7 +862,7 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  adm-zip@0.4.16: {}
+  adm-zip@0.6.0: {}
 
   aes-js@4.0.0-beta.5: {}
 
@@ -943,7 +946,7 @@ snapshots:
       '@nomicfoundation/hardhat-zod-utils': 3.0.5(zod@3.25.76)
       '@nomicfoundation/solidity-analyzer': 0.1.2
       '@sentry/core': 9.47.1
-      adm-zip: 0.4.16
+      adm-zip: 0.6.0
       chokidar: 4.0.3
       enquirer: 2.3.6
       ethereum-cryptography: 2.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,8 @@ allowBuilds:
   bufferutil@4.0.6: false
   esbuild@0.28.1: true
   utf-8-validate@5.0.9: false
+
+# Hardhat still declares adm-zip ^0.4.16. Force the first release patched for
+# GHSA-xcpc-8h2w-3j85 until Hardhat updates its dependency range upstream.
+overrides:
+  adm-zip: 0.6.0

--- a/scripts/maintenance-policy.cjs
+++ b/scripts/maintenance-policy.cjs
@@ -98,6 +98,11 @@ const RECORD_DIRECTORY = "compatibility/maintenance";
 const RECORD_NAME = /^([0-9]{4})-([a-z0-9]+(?:-[a-z0-9]+)*)\.json$/;
 const EXACT_SEMVER = /^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
 const EXACT_ACTION_TAG = /^v[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.-]+)?$/;
+const EXACT_GITHUB_ADVISORY =
+  /^GHSA-[23456789cfghjmpqrvwx]{4}(?:-[23456789cfghjmpqrvwx]{4}){2}$/;
+const HARDHAT_WARNING_ALLOWLIST =
+  "compatibility/compiler-warning-allowlist.json";
+const MAINTENANCE_POLICY_PATH = "scripts/maintenance-policy.cjs";
 
 function fail(message) {
   throw new Error(message);
@@ -300,6 +305,34 @@ function readPackage(root, reference = null) {
   return JSON.parse(
     repositoryFileBytes(root, "package.json", reference).toString("utf8")
   );
+}
+
+function readJsonFile(root, relativePath, reference = null) {
+  return JSON.parse(
+    repositoryFileBytes(root, relativePath, reference).toString("utf8")
+  );
+}
+
+function pnpmOverrides(root, reference = null) {
+  const text = repositoryFileBytes(
+    root,
+    "pnpm-workspace.yaml",
+    reference
+  ).toString("utf8");
+  const overrides = {};
+  const lines = text.split(/\r?\n/);
+  const start = lines.findIndex((line) => line === "overrides:");
+  if (start === -1) return overrides;
+  for (const line of lines.slice(start + 1)) {
+    if (line.length === 0 || /^\s*#/.test(line)) continue;
+    if (!line.startsWith("  ")) break;
+    const match = line.match(/^  ([A-Za-z0-9@/_.-]+): ([0-9A-Za-z.+-]+)$/);
+    if (!match || !EXACT_SEMVER.test(match[2]) || match[1] in overrides) {
+      fail("pnpm overrides must be unique exact package-version mappings");
+    }
+    overrides[match[1]] = match[2];
+  }
+  return sorted(overrides);
 }
 
 function packageSnapshot(root, reference = null) {
@@ -564,7 +597,7 @@ function validateRecordSchema(record, filename, sequence) {
     record.sequence !== sequence ||
     record.id !== filename.replace(/^[0-9]{4}-|\.json$/g, "") ||
     !/^[0-9a-f]{40}$/.test(record.baseCommit) ||
-    !["bootstrap", "github-actions", "javascript"].includes(record.category) ||
+    !["bootstrap", "governance", "github-actions", "javascript"].includes(record.category) ||
     record.transition?.kind !== record.category ||
     typeof record.summary !== "string" ||
     record.summary.trim().length < 12 ||
@@ -619,6 +652,82 @@ function validateBootstrapTransition(record) {
   if (!valuesEqual(record.changedFiles, BOOTSTRAP_CHANGED_FILES)) {
     fail("Bootstrap may change only the workflow and four maintenance support scripts");
   }
+}
+
+function validateSecurityOverrideTransitions(
+  changes,
+  root,
+  baseCommit,
+  targetReference
+) {
+  if (!Array.isArray(changes)) {
+    fail("Security override transitions must be an array");
+  }
+  const beforeOverrides = pnpmOverrides(root, baseCommit);
+  const afterOverrides = pnpmOverrides(root, targetReference);
+  const expectedOverrides = structuredClone(beforeOverrides);
+  const names = [];
+  for (const change of changes) {
+    exactKeys(
+      change,
+      ["advisory", "from", "name", "to"],
+      "Security override transition"
+    );
+    if (
+      typeof change.name !== "string" ||
+      !EXACT_GITHUB_ADVISORY.test(change.advisory) ||
+      !EXACT_SEMVER.test(change.to) ||
+      change.from !== (beforeOverrides[change.name] || null) ||
+      change.to === change.from
+    ) {
+      fail(`Invalid security override transition: ${change.name}`);
+    }
+    names.push(change.name);
+    expectedOverrides[change.name] = change.to;
+  }
+  if (
+    !valuesEqual(names, [...new Set(names)].sort()) ||
+    !valuesEqual(sorted(expectedOverrides), afterOverrides)
+  ) {
+    fail("Security overrides must be unique, sorted, and exact");
+  }
+}
+
+function validateGovernanceTransition(
+  record,
+  root,
+  baseCommit,
+  targetReference
+) {
+  exactKeys(
+    record.transition,
+    ["fromSha256", "kind", "path", "securityOverrides", "toSha256"],
+    "Governance transition"
+  );
+  const overrideChanges = record.transition.securityOverrides;
+  const expectedChangedFiles = [MAINTENANCE_POLICY_PATH];
+  if (Array.isArray(overrideChanges) && overrideChanges.length > 0) {
+    expectedChangedFiles.push("pnpm-lock.yaml", "pnpm-workspace.yaml");
+  }
+  if (
+    !valuesEqual(record.changedFiles, expectedChangedFiles.sort()) ||
+    record.transition.path !== MAINTENANCE_POLICY_PATH ||
+    !/^[0-9a-f]{64}$/.test(record.transition.fromSha256) ||
+    !/^[0-9a-f]{64}$/.test(record.transition.toSha256) ||
+    record.transition.fromSha256 === record.transition.toSha256 ||
+    fileSha256(root, MAINTENANCE_POLICY_PATH, baseCommit) !==
+      record.transition.fromSha256 ||
+    fileSha256(root, MAINTENANCE_POLICY_PATH, targetReference) !==
+      record.transition.toSha256
+  ) {
+    fail("Governance maintenance must bind one exact policy-file replacement");
+  }
+  validateSecurityOverrideTransitions(
+    overrideChanges,
+    root,
+    baseCommit,
+    targetReference
+  );
 }
 
 function validateActionDescriptor(value, label) {
@@ -685,19 +794,38 @@ function validateGithubActionTransition(
   }
 }
 
-function validateJavascriptTransition(record, beforePackage, afterPackage) {
+function validateJavascriptTransition(
+  record,
+  beforePackage,
+  afterPackage,
+  root,
+  baseCommit,
+  targetReference
+) {
   exactKeys(
     record.transition,
-    ["devDependencies", "kind"],
+    ["devDependencies", "hardhatWarningMetadata", "kind", "securityOverrides"],
     "JavaScript transition"
   );
   const changes = record.transition.devDependencies;
+  const hardhatMetadata = record.transition.hardhatWarningMetadata;
+  const overrideChanges = record.transition.securityOverrides;
+  if (!Array.isArray(overrideChanges)) {
+    fail("Security override transitions must be an array");
+  }
+  const expectedChangedFiles = ["package.json", "pnpm-lock.yaml"];
+  if (hardhatMetadata !== null) {
+    expectedChangedFiles.push(HARDHAT_WARNING_ALLOWLIST);
+  }
+  if (overrideChanges.length > 0) {
+    expectedChangedFiles.push("pnpm-workspace.yaml");
+  }
   if (
-    !valuesEqual(record.changedFiles, ["package.json", "pnpm-lock.yaml"]) ||
+    !valuesEqual(record.changedFiles, expectedChangedFiles.sort()) ||
     !Array.isArray(changes) ||
     changes.length === 0
   ) {
-    fail("JavaScript maintenance must update package.json and pnpm-lock.yaml");
+    fail("JavaScript maintenance changed files outside its declared transition");
   }
   const names = [];
   const expectedPackage = structuredClone(beforePackage);
@@ -722,6 +850,49 @@ function validateJavascriptTransition(record, beforePackage, afterPackage) {
   if (!valuesEqual(expectedPackage, afterPackage)) {
     fail("package.json changed outside declared existing devDependencies");
   }
+
+  validateSecurityOverrideTransitions(
+    overrideChanges,
+    root,
+    baseCommit,
+    targetReference
+  );
+
+  const hardhatChange = changes.find((change) => change.name === "hardhat");
+  if (hardhatMetadata === null) {
+    if (hardhatChange) {
+      fail("Hardhat maintenance must update its reviewed warning metadata");
+    }
+  } else {
+    exactKeys(
+      hardhatMetadata,
+      ["from", "to"],
+      "Hardhat warning metadata transition"
+    );
+    const beforeAllowlist = readJsonFile(
+      root,
+      HARDHAT_WARNING_ALLOWLIST,
+      baseCommit
+    );
+    const afterAllowlist = readJsonFile(
+      root,
+      HARDHAT_WARNING_ALLOWLIST,
+      targetReference
+    );
+    if (
+      !hardhatChange ||
+      hardhatMetadata.from !== hardhatChange.from ||
+      hardhatMetadata.to !== hardhatChange.to ||
+      beforeAllowlist.tools?.hardhat?.version !== hardhatMetadata.from ||
+      afterAllowlist.tools?.hardhat?.version !== hardhatMetadata.to
+    ) {
+      fail("Hardhat warning metadata must match the package transition");
+    }
+    beforeAllowlist.tools.hardhat.version = hardhatMetadata.to;
+    if (!valuesEqual(beforeAllowlist, afterAllowlist)) {
+      fail("Hardhat warning allowlist changed outside its reviewed version");
+    }
+  }
 }
 
 function validateTransition(
@@ -738,6 +909,24 @@ function validateTransition(
 ) {
   if (record.category === "bootstrap") {
     validateBootstrapTransition(record);
+    return;
+  }
+  if (record.category === "governance") {
+    if (
+      !valuesEqual(beforeActions, afterActions) ||
+      !valuesEqual(beforePackages, afterPackages) ||
+      !valuesEqual(beforeToolchain, afterToolchain)
+    ) {
+      fail(
+        "Governance maintenance may not change dependencies or the pinned toolchain"
+      );
+    }
+    validateGovernanceTransition(
+      record,
+      root,
+      baseCommit,
+      targetReference
+    );
     return;
   }
   if (!valuesEqual(beforeToolchain, afterToolchain)) {
@@ -762,7 +951,10 @@ function validateTransition(
   validateJavascriptTransition(
     record,
     readPackage(root, baseCommit),
-    readPackage(root, targetReference)
+    readPackage(root, targetReference),
+    root,
+    baseCommit,
+    targetReference
   );
 }
 
@@ -952,6 +1144,7 @@ module.exports = Object.freeze({
   stage13AnchorSha256,
   toolchainSnapshot,
   validateGithubActionTransition,
+  validateGovernanceTransition,
   validateJavascriptTransition,
   validateMaintenanceLedger,
 });


### PR DESCRIPTION
<!-- modernization-chronology:start -->
## Modernization chronology

- **Phase:** Maintenance 05 — advisory override and ledger extension
- **Predecessor:** [#101 — actions/upload-artifact v7.0.1](https://github.com/721labs/partial-common-ownership/pull/101)
- **This checkpoint:** [#106](https://github.com/721labs/partial-common-ownership/pull/106) — merged at [17c14c68b94931c9c0896248e75fe1f6002fb8cb](https://github.com/721labs/partial-common-ownership/commit/17c14c68b94931c9c0896248e75fe1f6002fb8cb) on 2026-07-18T06:25:03Z
- **Successor:** [#103 — Hardhat 3.10 maintenance](https://github.com/721labs/partial-common-ownership/pull/103)
- **Relationship:** Serialized maintenance order: this checkpoint remediates the adm-zip advisory already present on main and teaches the ledger to review Hardhat warning metadata before the Hardhat package transition.
<!-- modernization-chronology:end -->

## Why

PR #103 exposed two maintenance transitions that the append-only ledger cannot currently express:

1. Hardhat upgrades must update `compatibility/compiler-warning-allowlist.json` so the warning gate records the exact reviewed Hardhat version.
2. The newly published high-severity advisory [GHSA-xcpc-8h2w-3j85](https://github.com/advisories/GHSA-xcpc-8h2w-3j85) affects Hardhat's transitive `adm-zip@0.4.16`. Hardhat still declares `^0.4.16`, so the repository needs an exact, named pnpm override to the patched `0.6.0` release until upstream changes its range.

The existing JavaScript maintenance schema permits only `package.json` and `pnpm-lock.yaml`. That correctly rejected #103, but it also means a reviewer cannot authorize either of the necessary supporting changes without weakening or bypassing the ledger.

This PR is a prerequisite for #103. It remediates the advisory already present on `main`; it does not upgrade Hardhat.

## What changes

- Add a narrowly scoped `governance` record type that can bind one exact replacement of `scripts/maintenance-policy.cjs`.
- Extend JavaScript records to declare:
  - exact advisory-backed pnpm override transitions; and
  - the exact Hardhat version-only change in the compiler-warning allowlist.
- Validate that override names are unique and sorted, advisory IDs use the GitHub Advisory format, and target versions are exact semver.
- Validate that the warning allowlist changes only at `tools.hardhat.version`, matching the declared Hardhat package transition.
- Apply the exact `adm-zip@0.6.0` override and regenerate the frozen lockfile, reducing the audit result from one high finding to zero.
- Keep production contracts, actions, package snapshots, and the pinned Node/pnpm/Foundry/Solidity toolchain unchanged.

## Stack and chronology

- Base: #101 merged at `318ad540bf4dd95810db4b0380fe67734b726fab`.
- This PR must merge before #103 is rebuilt.
- After merge, #103 will be rebuilt as a single append-only JavaScript maintenance commit with its own record and the reviewed Hardhat 3.10.0 warning metadata. It will inherit the security override from this PR.

## Reviewer record

- Final commit: `1465db8` (one commit; first parent `318ad540bf4dd95810db4b0380fe67734b726fab`).
- Append-only record: `compatibility/maintenance/0006-security-override-policy.json`, with `sourcePullRequests: [106]` and exact before/after policy hashes.
- Local pinned-toolchain gates: maintenance policy, typecheck, Forge/Hardhat tests, compatibility manifest, and audit all passed.
- GitHub Actions run `29633872887`: all nine required PR jobs passed; the scheduled-only job was correctly skipped.
- Audit result: `critical=0, high=0, moderate=0, low=0, info=0`.
